### PR TITLE
Expose Caller Address in ERC-20 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/api/ERC20API.ts
+++ b/src/api/ERC20API.ts
@@ -116,12 +116,13 @@ export default class ERC20API {
     tokenAddress: Address,
     ownerAddress: Address,
     spenderAddress: Address,
+    callerAddress: Address = undefined,
   ): Promise<BigNumber> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
     this.assert.schema.isValidAddress('ownerAddress', ownerAddress);
     this.assert.schema.isValidAddress('spenderAddress', spenderAddress);
 
-    return this.erc20Wrapper.allowance(tokenAddress, ownerAddress, spenderAddress);
+    return this.erc20Wrapper.allowance(tokenAddress, ownerAddress, spenderAddress, callerAddress);
   }
 
   /**

--- a/src/api/ERC20API.ts
+++ b/src/api/ERC20API.ts
@@ -34,10 +34,7 @@ import Assertions from '../assertions';
 export default class ERC20API {
   private assert: Assertions;
   private erc20Wrapper: ERC20Wrapper;
-  public constructor(
-    provider: Provider,
-    assertions?: Assertions
-  ) {
+  public constructor(provider: Provider, assertions?: Assertions) {
     this.erc20Wrapper = new ERC20Wrapper(provider);
     this.assert = assertions || new Assertions();
   }
@@ -47,61 +44,86 @@ export default class ERC20API {
    *
    * @param  tokenAddress  Address of the ERC20 token
    * @param  userAddress   Address of the user
+   * @param  callerAddress Optional. The address of user transferring from.
    * @return               The balance of the ERC20 token in BigNumber format
    */
-  public async getBalanceAsync(tokenAddress: Address, userAddress: Address): Promise<BigNumber> {
+  public async getBalanceAsync(
+    tokenAddress: Address,
+    userAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<BigNumber> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
     this.assert.schema.isValidAddress('userAddress', userAddress);
 
-    return this.erc20Wrapper.balanceOf(tokenAddress, userAddress);
+    return this.erc20Wrapper.balanceOf(
+      tokenAddress,
+      userAddress,
+      callerAddress
+    );
   }
 
   /**
    * Gets name of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
+   * @param  callerAddress Optional. The address of user transferring from.
    * @return               The name of the ERC20 token
    */
-  public async getTokenNameAsync(tokenAddress: Address): Promise<string> {
+  public async getTokenNameAsync(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<string> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
 
-    return this.erc20Wrapper.name(tokenAddress);
+    return this.erc20Wrapper.name(tokenAddress, callerAddress);
   }
 
   /**
    * Gets symbol of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
+   * @param  callerAddress Optional. The address of user transferring from.
    * @return               The symbol of the ERC20 token
    */
-  public async getTokenSymbolAsync(tokenAddress: Address): Promise<string> {
+  public async getTokenSymbolAsync(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<string> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
 
-    return this.erc20Wrapper.symbol(tokenAddress);
+    return this.erc20Wrapper.symbol(tokenAddress, callerAddress);
   }
 
   /**
    * Gets the total supply of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
+   * @param  callerAddress Optional. The address of user transferring from.
    * @return               The total supply of ERC-20 in BigNumber format
    */
-  public async getTotalSupplyAsync(tokenAddress: Address): Promise<BigNumber> {
+  public async getTotalSupplyAsync(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<BigNumber> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
 
-    return this.erc20Wrapper.totalSupply(tokenAddress);
+    return this.erc20Wrapper.totalSupply(tokenAddress, callerAddress);
   }
 
   /**
    * Gets decimals of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
+   * @param  callerAddress Optional. The address of user transferring from.
    * @return               The decimals of the ERC20 token
    */
-  public async getDecimalsAsync(tokenAddress: Address): Promise<BigNumber> {
+  public async getDecimalsAsync(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<BigNumber> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
 
-    return this.erc20Wrapper.decimals(tokenAddress);
+    return this.erc20Wrapper.decimals(tokenAddress, callerAddress);
   }
 
   /**
@@ -110,19 +132,25 @@ export default class ERC20API {
    * @param  tokenAddress      Address of the token
    * @param  ownerAddress      Address of the owner
    * @param  spenderAddress    Address of the spender
+   * @param  callerAddress     Optional. The address of user transferring from.
    * @return                   The allowance of the spender in BigNumber format
    */
   public async getAllowanceAsync(
     tokenAddress: Address,
     ownerAddress: Address,
     spenderAddress: Address,
-    callerAddress: Address = undefined,
+    callerAddress: Address = undefined
   ): Promise<BigNumber> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
     this.assert.schema.isValidAddress('ownerAddress', ownerAddress);
     this.assert.schema.isValidAddress('spenderAddress', spenderAddress);
 
-    return this.erc20Wrapper.allowance(tokenAddress, ownerAddress, spenderAddress, callerAddress);
+    return this.erc20Wrapper.allowance(
+      tokenAddress,
+      ownerAddress,
+      spenderAddress,
+      callerAddress
+    );
   }
 
   /**
@@ -141,13 +169,19 @@ export default class ERC20API {
     to: Address,
     value: BigNumber,
     callerAddress: Address = undefined,
-    txOpts: TransactionOverrides = {},
+    txOpts: TransactionOverrides = {}
   ): Promise<ContractTransaction> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
     this.assert.schema.isValidAddress('toAddress', to);
     this.assert.schema.isValidNumber('value', value);
 
-    return await this.erc20Wrapper.transfer(tokenAddress, to, value, callerAddress, txOpts);
+    return await this.erc20Wrapper.transfer(
+      tokenAddress,
+      to,
+      value,
+      callerAddress,
+      txOpts
+    );
   }
 
   /**
@@ -171,7 +205,13 @@ export default class ERC20API {
     this.assert.schema.isValidAddress('spenderAddress', spenderAddress);
     this.assert.schema.isValidNumber('value', value);
 
-    return this.erc20Wrapper.approve(tokenAddress, spenderAddress, value, callerAddress, txOpts);
+    return this.erc20Wrapper.approve(
+      tokenAddress,
+      spenderAddress,
+      value,
+      callerAddress,
+      txOpts
+    );
   }
 
   /**
@@ -191,13 +231,20 @@ export default class ERC20API {
     to: Address,
     value: BigNumber,
     callerAddress: Address = undefined,
-    txOpts: TransactionOverrides = {},
+    txOpts: TransactionOverrides = {}
   ): Promise<ContractTransaction> {
     this.assert.schema.isValidAddress('tokenAddress', tokenAddress);
     this.assert.schema.isValidAddress('toAddress', to);
     this.assert.schema.isValidAddress('fromAddress', from);
     this.assert.schema.isValidNumber('value', value);
 
-    return this.erc20Wrapper.transferFrom(tokenAddress, from, to, value, callerAddress, txOpts);
+    return this.erc20Wrapper.transferFrom(
+      tokenAddress,
+      from,
+      to,
+      value,
+      callerAddress,
+      txOpts
+    );
   }
 }

--- a/src/wrappers/set-protocol-v2/ERC20Wrapper.ts
+++ b/src/wrappers/set-protocol-v2/ERC20Wrapper.ts
@@ -122,7 +122,7 @@ export default class ERC20Wrapper {
    * Gets decimals of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
-   * @param  userAddress   Address of the user
+   * @param  callerAddress Address of the method caller
    * @return               The decimals of the ERC20 token
    */
   public async decimals(

--- a/src/wrappers/set-protocol-v2/ERC20Wrapper.ts
+++ b/src/wrappers/set-protocol-v2/ERC20Wrapper.ts
@@ -45,10 +45,18 @@ export default class ERC20Wrapper {
    *
    * @param  tokenAddress  Address of the ERC20 token
    * @param  userAddress   Address of the user
+   * @param  callerAddress Address of the method caller
    * @return               The balance of the ERC20 token
    */
-  public async balanceOf(tokenAddress: Address, userAddress: Address): Promise<BigNumber> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress);
+  public async balanceOf(
+    tokenAddress: Address,
+    userAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<BigNumber> {
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.balanceOf(userAddress);
   }
@@ -57,10 +65,17 @@ export default class ERC20Wrapper {
    * Gets name of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
+   * @param  callerAddress Address of the method caller
    * @return               The name of the ERC20 token
    */
-  public async name(tokenAddress: Address): Promise<string> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress);
+  public async name(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<string> {
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.name();
   }
@@ -69,10 +84,17 @@ export default class ERC20Wrapper {
    * Gets balance of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
+   * @param  callerAddress Address of the method caller
    * @return               The symbol of the ERC20 token
    */
-  public async symbol(tokenAddress: Address): Promise<string> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress);
+  public async symbol(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<string> {
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.symbol();
   }
@@ -81,10 +103,17 @@ export default class ERC20Wrapper {
    * Gets the total supply of the ERC20 token
    *
    * @param  tokenAddress  Address of the ERC20 token
+   * @param  callerAddress Address of the method caller
    * @return               The symbol of the ERC20 token
    */
-  public async totalSupply(tokenAddress: Address): Promise<BigNumber> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress);
+  public async totalSupply(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<BigNumber> {
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.totalSupply();
   }
@@ -96,8 +125,14 @@ export default class ERC20Wrapper {
    * @param  userAddress   Address of the user
    * @return               The decimals of the ERC20 token
    */
-  public async decimals(tokenAddress: Address): Promise<BigNumber> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress);
+  public async decimals(
+    tokenAddress: Address,
+    callerAddress: Address = undefined
+  ): Promise<BigNumber> {
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.decimals();
   }
@@ -108,15 +143,19 @@ export default class ERC20Wrapper {
    * @param  tokenAddress      Address of the token
    * @param  ownerAddress      Address of the owner
    * @param  spenderAddress    Address of the spender
+   * @param  callerAddress     Address of the method caller
    * @return                   The allowance of the spender
    */
   public async allowance(
     tokenAddress: Address,
     ownerAddress: Address,
     spenderAddress: Address,
-    callerAddress: Address = undefined,
+    callerAddress: Address = undefined
   ): Promise<BigNumber> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress, callerAddress);
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.allowance(ownerAddress, spenderAddress);
   }
@@ -137,10 +176,13 @@ export default class ERC20Wrapper {
     to: Address,
     value: BigNumber,
     callerAddress: Address = undefined,
-    txOpts?: TransactionOverrides,
+    txOpts?: TransactionOverrides
   ): Promise<ContractTransaction> {
     const txOptions = await generateTxOpts(txOpts);
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress, callerAddress);
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.transfer(to, value, txOptions);
   }
@@ -163,9 +205,12 @@ export default class ERC20Wrapper {
     to: Address,
     value: BigNumber,
     callerAddress: Address = undefined,
-    txOpts?: TransactionOverrides,
+    txOpts?: TransactionOverrides
   ): Promise<ContractTransaction> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress, callerAddress);
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
     const txOptions = await generateTxOpts(txOpts);
 
     return await tokenInstance.transferFrom(from, to, value, txOptions);
@@ -186,10 +231,13 @@ export default class ERC20Wrapper {
     spenderAddress: Address,
     value: BigNumber,
     callerAddress: Address = undefined,
-    txOpts?: TransactionOverrides,
+    txOpts?: TransactionOverrides
   ): Promise<ContractTransaction> {
     const txOptions = await generateTxOpts(txOpts);
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress, callerAddress);
+    const tokenInstance = await this.contracts.loadERC20Async(
+      tokenAddress,
+      callerAddress
+    );
 
     return await tokenInstance.approve(spenderAddress, value, txOptions);
   }

--- a/src/wrappers/set-protocol-v2/ERC20Wrapper.ts
+++ b/src/wrappers/set-protocol-v2/ERC20Wrapper.ts
@@ -114,8 +114,9 @@ export default class ERC20Wrapper {
     tokenAddress: Address,
     ownerAddress: Address,
     spenderAddress: Address,
+    callerAddress: Address = undefined,
   ): Promise<BigNumber> {
-    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress);
+    const tokenInstance = await this.contracts.loadERC20Async(tokenAddress, callerAddress);
 
     return await tokenInstance.allowance(ownerAddress, spenderAddress);
   }

--- a/test/api/ERC20API.spec.ts
+++ b/test/api/ERC20API.spec.ts
@@ -43,16 +43,19 @@ describe('ERC20API', () => {
   describe('#getBalanceAsync', () => {
     let subjectTokenAddress: Address;
     let subjectHolderAddress: Address;
+    let nullCallerAddress: Address;
 
     beforeEach(async () => {
       subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
       subjectHolderAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
     async function subject(): Promise<BigNumber> {
       return await erc20API.getBalanceAsync(
         subjectTokenAddress,
-        subjectHolderAddress
+        subjectHolderAddress,
+        nullCallerAddress,
       );
     }
 
@@ -61,7 +64,8 @@ describe('ERC20API', () => {
 
       expect(erc20Wrapper.balanceOf).to.have.beenCalledWith(
         subjectTokenAddress,
-        subjectHolderAddress
+        subjectHolderAddress,
+        nullCallerAddress,
       );
     });
 
@@ -78,21 +82,24 @@ describe('ERC20API', () => {
 
   describe('#getTokenNameAsync', () => {
     let subjectTokenAddress: Address;
+    let nullCallerAddress: Address;
 
     beforeEach(async () => {
       subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
     async function subject(): Promise<string> {
       return await erc20API.getTokenNameAsync(
         subjectTokenAddress,
+        nullCallerAddress,
       );
     }
 
     it('should call the ERC20Wrapper with correct params', async () => {
       await subject();
 
-      expect(erc20Wrapper.name).to.have.beenCalledWith(subjectTokenAddress);
+      expect(erc20Wrapper.name).to.have.beenCalledWith(subjectTokenAddress, nullCallerAddress);
     });
 
     describe('when the SetToken address is invalid', () => {
@@ -108,21 +115,24 @@ describe('ERC20API', () => {
 
   describe('#getTokenSymbolAsync', () => {
     let subjectTokenAddress: Address;
+    let nullCallerAddress: Address;
 
     beforeEach(async () => {
       subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
     async function subject(): Promise<string> {
       return await erc20API.getTokenSymbolAsync(
         subjectTokenAddress,
+        nullCallerAddress,
       );
     }
 
     it('should call the ERC20Wrapper with correct params', async () => {
       await subject();
 
-      expect(erc20Wrapper.symbol).to.have.beenCalledWith(subjectTokenAddress);
+      expect(erc20Wrapper.symbol).to.have.beenCalledWith(subjectTokenAddress, nullCallerAddress);
     });
 
     describe('when the SetToken address is invalid', () => {
@@ -138,21 +148,24 @@ describe('ERC20API', () => {
 
   describe('#getTotalSupplyAsync', () => {
     let subjectTokenAddress: Address;
+    let nullCallerAddress: Address;
 
     beforeEach(async () => {
       subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
     async function subject(): Promise<BigNumber> {
       return await erc20API.getTotalSupplyAsync(
         subjectTokenAddress,
+        nullCallerAddress,
       );
     }
 
     it('should call the ERC20Wrapper with correct params', async () => {
       await subject();
 
-      expect(erc20Wrapper.totalSupply).to.have.beenCalledWith(subjectTokenAddress);
+      expect(erc20Wrapper.totalSupply).to.have.beenCalledWith(subjectTokenAddress, nullCallerAddress);
     });
 
     describe('when the SetToken address is invalid', () => {
@@ -168,21 +181,24 @@ describe('ERC20API', () => {
 
   describe('#getDecimalsAsync', () => {
     let subjectTokenAddress: Address;
+    let nullCallerAddress: Address;
 
     beforeEach(async () => {
       subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
     async function subject(): Promise<BigNumber> {
       return await erc20API.getDecimalsAsync(
         subjectTokenAddress,
+        nullCallerAddress,
       );
     }
 
     it('should call the ERC20Wrapper with correct params', async () => {
       await subject();
 
-      expect(erc20Wrapper.decimals).to.have.beenCalledWith(subjectTokenAddress);
+      expect(erc20Wrapper.decimals).to.have.beenCalledWith(subjectTokenAddress, nullCallerAddress);
     });
 
     describe('when the SetToken address is invalid', () => {
@@ -200,18 +216,21 @@ describe('ERC20API', () => {
     let subjectTokenAddress: Address;
     let subjectUserAddress: Address;
     let subjectSpenderAddress: Address;
+    let nullCallerAddress: Address;
 
     beforeEach(async () => {
       subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
       subjectUserAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
       subjectSpenderAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
     async function subject(): Promise<BigNumber> {
       return await erc20API.getAllowanceAsync(
         subjectTokenAddress,
         subjectUserAddress,
-        subjectSpenderAddress
+        subjectSpenderAddress,
+        nullCallerAddress
       );
     }
 
@@ -221,7 +240,8 @@ describe('ERC20API', () => {
       expect(erc20Wrapper.allowance).to.have.beenCalledWith(
         subjectTokenAddress,
         subjectUserAddress,
-        subjectSpenderAddress
+        subjectSpenderAddress,
+        nullCallerAddress,
       );
     });
 


### PR DESCRIPTION
* Allows the user to pass in a caller address to the ERC-20 API for checking allowances.
* Without this, logged-out allowance fetches from infura fail