### PR TITLE
Fix circleci badge (attempt 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center"><img src="https://s3-us-west-1.amazonaws.com/set-protocol/img/assets/set-protocol-logo.png" width="64" /></p>
 
 <p align="center">
-  <a href="https://circleci.com/gh/SetProtocol/set.js/tree/master" target="_blank" rel="noopener">
-    <img src="https://circleci.com/gh/SetProtocol/set.js.svg?style=shield" />
+  <a href="https://circleci.com/gh/SetProtocol/set.js">
+    <img src="https://img.shields.io/circleci/build/gh/SetProtocol/set.js/master" />
   </a>
   <a href='https://github.com/SetProtocol/set.js/blob/master/LICENSE' target="_blank" rel="noopener">
     <img src='https://img.shields.io/badge/License-Apache%202.0-blue.svg' alt='License' />


### PR DESCRIPTION
It looks like CircleCI badges generated via [these steps](https://circleci.com/docs/2.0/status-badges/#creating-badges-for-private-repositories96166267374796c653d736869656c64) don't render correctly in this README. My suspicion is that the `.` in set.js is a possible cause.

I generated a shield badge via https://shields.io/category/build and it works in the preview