### PR TITLE
[WIP] Add Arbitrum support

### DIFF
--- a/src/api/utils/coingecko.ts
+++ b/src/api/utils/coingecko.ts
@@ -43,8 +43,10 @@ export const ETH_CURRENCY_CODE = 'eth';
  * @title CoinGeckoDataService
  * @author Set Protocol
  *
- * A utility library for fetching token metadata and coin prices from Coingecko for Ethereum
- * and Polygon chains
+ * A utility library for fetching token metadata and coin prices from Coingecko
+ * + Ethereum: (1)
+ * + Polygon (137)
+ * + Arbitrum (42161)
  */
 export class CoinGeckoDataService {
   chainId: number;
@@ -102,6 +104,9 @@ export class CoinGeckoDataService {
       case 137:
         this.tokenList = await this.fetchPolygonTokenList();
         break;
+      case 42161:
+        this.tokenList = await this.fetchArbitrumTokenList();
+        break;
     }
     this.tokenMap = this.convertTokenListToAddressMap(this.tokenList);
 
@@ -136,6 +141,7 @@ export class CoinGeckoDataService {
     switch (this.chainId) {
       case 1: return 'ethereum';
       case 137: return 'polygon-pos';
+      case 42161: return 'arbitrum';
       default: return '';
     }
   }
@@ -243,5 +249,11 @@ export class CoinGeckoDataService {
 
     const data = (await axios.get(url)).data;
     return data;
+  }
+
+  private async fetchArbitrumTokenList(): Promise<CoinGeckoTokenData[]> {
+    const url = 'https://bridge.arbitrum.io/token-list-42161.json';
+    const response = await axios.get(url);
+    return response.data.tokens;
   }
 }

--- a/src/assertions/CommonAssertions.ts
+++ b/src/assertions/CommonAssertions.ts
@@ -117,7 +117,7 @@ export class CommonAssertions {
   }
 
   public isSupportedChainId(chainId: number) {
-    const validChainIds = [1, 137];
+    const validChainIds = [1, 137, 42161];
 
     if ( !validChainIds.includes(chainId)) {
       throw new Error(`Unsupported chainId: ${chainId}. Must be one of ${validChainIds}`);

--- a/test/fixtures/tradeQuote.ts
+++ b/test/fixtures/tradeQuote.ts
@@ -153,6 +153,47 @@ export const tradeQuoteFixtures = {
     },
   },
 
+  // Endpoint used by UniswapV3
+  arbitrumBridgeTokenRequest: 'https://bridge.arbitrum.io/token-list-42161.json',
+  arbitrumBridgeTokenResponse: {
+    data: {
+      tokens: [{
+        'chainId': 42161,
+        'address': '0x0e15258734300290a651FdBAe8dEb039a8E7a2FA',
+        'name': 'Alchemy',
+        'symbol': 'ALCH',
+        'decimals': 18,
+        'logoURI': '',
+        'extensions': {
+            'l1Address': '0x0000A1c00009A619684135B824Ba02f7FbF3A572',
+            'l1GatewayAddress': '0xa3A7B6F88361F48403514059F1F16C8E78d60EeC',
+        },
+      }, {
+        'chainId': 42161,
+        'address': '0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E',
+        'name': 'Badger',
+        'symbol': 'BADGER',
+        'decimals': 18,
+        'logoURI': '',
+        'extensions': {
+            'l1Address': '0x3472A5A71965499acd81997a54BBA8D852C6E53d',
+            'l1GatewayAddress': '0xa3A7B6F88361F48403514059F1F16C8E78d60EeC',
+        },
+      }, {
+        'chainId': 42161,
+        'address': '0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8',
+        'name': 'Balancer',
+        'symbol': 'BAL',
+        'decimals': 18,
+        'logoURI': '',
+        'extensions': {
+            'l1Address': '0xba100000625a3754423978a60c9317c58a424e3D',
+            'l1GatewayAddress': '0xa3A7B6F88361F48403514059F1F16C8E78d60EeC',
+        },
+      }],
+    },
+  },
+
   coinGeckoPricesRequestEth: 'https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2,0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e&vs_currencies=usd,usd,usd',
   coinGeckoPricesResponseEth: {
     data: {


### PR DESCRIPTION
Draft PR to add Arbitrum related resources as they become available. The main technical blocker here is that `0x` cannot integrate with Arbitrum because they do not support Geth's `eth_call` [overrides API][1] (I don't see an issue about the topic open in [Arbitrum's repo][2] - might be a while before it's resolved).
 

- [x] Add arbitrum token metadata fetching
- [ ]  Add arbitrum coin price fetching
- [ ] Add gas price oracle support
  + We can get the L2 "gas bid" via `eth_gasPrice` in the absence of an oracle service. Just need Infura (paid) or Alchemy (free) api tokens
- [ ] Add ZeroEx trade quote fetching 

[1]: https://geth.ethereum.org/docs/rpc/ns-eth
[2]: https://github.com/OffchainLabs/arbitrum