### PR TITLE
JSDoc comments for Position

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -31,11 +31,29 @@ export type SetDetails = {
   totalSupply: BigNumber;
 };
 
+/**
+ * The base definition of a SetToken Position
+ */
 export type Position = {
+  /**
+   * Address of token in the Position
+   */
   component: string;
+  /**
+   * If not in default state, the address of associated module
+   */
   module: Address;
+  /**
+   * Each unit is the # of components per 10^18 of a SetToken
+   */
   unit: BigNumber;
+  /**
+   * The type of position denoted as a uint8
+   */
   positionState: number;
+  /**
+   * Arbitrary data
+   */
   data: string;
 };
 


### PR DESCRIPTION
While working on https://github.com/SetProtocol/index-ui/pull/422 I
would've liked to see JSDoc comments for `Position`. I found docs on
https://docs.tokensets.com/contracts/core-contracts/set-token#getpositions
so I added them inline so devs can see them while using types from
this package.

If reviewers approve of a change like this, I can add doc
comments to other types in this package. I would fetch docs from
https://docs.tokensets.com/contracts but open to other ideas.