### PR TITLE
Add API and Wrapper classes for DebtIssuanceModuleV2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@0xproject/types": "^1.1.4",
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
-        "@setprotocol/set-protocol-v2": "^0.1.1",
+        "@setprotocol/set-protocol-v2": "^0.1.2",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -29,6 +29,7 @@ import {
   NavIssuanceAPI,
   PriceOracleAPI,
   DebtIssuanceAPI,
+  DebtIssuanceV2API,
 } from './api/index';
 
 const ethersProviders = require('ethers').providers;
@@ -97,6 +98,13 @@ class Set {
   public debtIssuance: DebtIssuanceAPI;
 
   /**
+   * An instance of the DebtIssuanceV2API class. Contains interfaces for interacting
+   * with the DebtIssuanceModuleV2 contract to issue and redeem tokens that accrue interest.
+   * Primarily used for ALM.
+   */
+  public debtIssuanceV2: DebtIssuanceV2API;
+
+  /**
    * An instance of the BlockchainAPI class. Contains interfaces for
    * interacting with the blockchain
    */
@@ -127,6 +135,7 @@ class Set {
     this.navIssuance = new NavIssuanceAPI(ethersProvider, config.navIssuanceModuleAddress);
     this.priceOracle = new PriceOracleAPI(ethersProvider, config.masterOracleAddress);
     this.debtIssuance = new DebtIssuanceAPI(ethersProvider, config.debtIssuanceModuleAddress);
+    this.debtIssuanceV2 = new DebtIssuanceV2API(ethersProvider, config.debtIssuanceModuleV2Address);
     this.blockchain = new BlockchainAPI(ethersProvider, assertions);
   }
 }

--- a/src/api/DebtIssuanceV2API.ts
+++ b/src/api/DebtIssuanceV2API.ts
@@ -1,0 +1,237 @@
+/*
+  Copyright 2021 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { ContractTransaction } from 'ethers';
+import { Provider } from '@ethersproject/providers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ADDRESS_ZERO } from '@setprotocol/set-protocol-v2/dist/utils/constants';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { BigNumber } from 'ethers/lib/ethers';
+
+import DebtIssuanceModuleV2Wrapper from '../wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper';
+import Assertions from '../assertions';
+
+/**
+ * @title  AlmIssuanceAPI
+ * @author Set Protocol
+ *
+ * The DebtIssuanceModuleV2API exposes issue and redeem functionality for Sets that contain poitions that accrue
+ * interest per block. The getter function syncs the position balance to the current block, so subsequent blocks
+ * will cause the position value to be slightly out of sync (a buffer is needed). This API is primarily used for Sets
+ * that rely on the ALM contracts to manage debt. The manager can define arbitrary issuance logic
+ * in the manager hook, as well as specify issue and redeem fees.
+ *
+ */
+export default class AlmIssuanceAPI {
+  private debtIssuanceModuleV2Wrapper: DebtIssuanceModuleV2Wrapper;
+  private assert: Assertions;
+
+  public constructor(provider: Provider, debtIssuanceModuleV2Address: Address, assertions?: Assertions) {
+    this.debtIssuanceModuleV2Wrapper = new DebtIssuanceModuleV2Wrapper(provider, debtIssuanceModuleV2Address);
+    this.assert = assertions || new Assertions();
+  }
+
+  /**
+   * Initializes the DebtIssuanceModuleV2 to the SetToken. Only callable by the SetToken's manager.
+   *
+   * @param setTokenAddress             Address of the SetToken to initialize
+   * @param maxManagerFee               Maximum fee that can be charged on issue and redeem
+   * @param managerIssueFee             Fee to charge on issuance
+   * @param managerRedeemFee            Fee to charge on redemption
+   * @param feeRecipient                Address to send fees to
+   * @param managerIssuanceHook         Instance of the Manager Contract with the Pre-Issuance Hook function
+   * @param txOpts                      Overrides for transaction (optional)
+   *
+   * @return                            Transaction hash of the initialize transaction
+   */
+  public async initializeAsync(
+    setTokenAddress: Address,
+    maxManagerFee: BigNumber,
+    managerIssueFee: BigNumber,
+    managerRedeemFee: BigNumber,
+    feeRecipient: Address,
+    managerIssuanceHook: Address = ADDRESS_ZERO,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('feeRecipient', feeRecipient);
+
+    return await this.debtIssuanceModuleV2Wrapper.initialize(
+      setTokenAddress,
+      maxManagerFee,
+      managerIssueFee,
+      managerRedeemFee,
+      feeRecipient,
+      managerIssuanceHook,
+      callerAddress,
+      txOpts,
+    );
+  }
+
+  /**
+   * Issue a SetToken from its underlying positions
+   *
+   * @param  setTokenAddress             Address of the SetToken contract to issue
+   * @param  quantity                    Quantity to issue
+   * @param  setTokenRecipientAddress    Address of the recipient of the issued SetToken
+   * @param  callerAddress               Address of caller (optional)
+   * @return                             Transaction hash of the issuance transaction
+   */
+  public async issueAsync(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('setTokenRecipientAddress', setTokenRecipientAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.issue(
+      setTokenAddress,
+      quantity,
+      setTokenRecipientAddress,
+      callerAddress,
+      txOpts
+    );
+  }
+
+  /**
+   * Redeem a SetToken into its underlying positions
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to redeem
+   * @param  setTokenRecipientAddress  Address of recipient of component tokens from redemption
+   * @param  callerAddress             Address of caller (optional)
+   * @return                           Transaction hash of the redemption transaction
+   */
+  public async redeemAsync(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('setTokenRecipientAddress', setTokenRecipientAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.redeem(
+      setTokenAddress,
+      quantity,
+      setTokenRecipientAddress,
+      callerAddress,
+      txOpts
+    );
+  }
+
+  /**
+   * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well
+   * as amount of debt that will be returned to caller. Values DO NOT take into account any updates from pre action
+   * manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to issue
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   */
+  public async getRequiredComponentIssuanceUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.getRequiredComponentIssuanceUnits(
+      setTokenAddress,
+      quantity,
+      callerAddress,
+    );
+  }
+
+  /**
+   * Calculates the amount of each component will be returned on redemption net of fees as well as how much debt needs
+   * to be paid down to redeem. Values DO NOT take into account any updates from pre action manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to redeem
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   */
+  public async getRequiredComponentRedemptionUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.getRequiredComponentRedemptionUnits(
+      setTokenAddress,
+      quantity,
+      callerAddress,
+    );
+  }
+
+  /**
+   * Calculates the manager fee, protocol fee and resulting totalQuantity to use when calculating unit amounts. If fees
+   * are charged they are added to the total issue quantity, for example 1% fee on 100 Sets means 101 Sets are minted
+   * by caller, the _to address receives 100 and the feeRecipient receives 1. Conversely, on redemption the redeemer
+   * will only receive the collateral that collateralizes 99 Sets, while the additional Set is given to the
+   * feeRecipient.
+   *
+   * @param setTokenAddress  Instance of the SetToken to issue
+   * @param quantity         Amount of SetToken issuer wants to receive/redeem
+   * @param isIssue          If issuing or redeeming
+   *
+   * @return BigNumber       Total amount of Sets to be issued/redeemed with fee adjustment
+   * @return BigNumber       Sets minted to the manager
+   * @return BigNumber       Sets minted to the protocol
+   */
+  public async calculateTotalFeesAsync(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    isIssue: boolean,
+    callerAddress: Address = undefined,
+  ): Promise<
+      [BigNumber, BigNumber, BigNumber] & {
+        totalQuantity: BigNumber;
+        managerFee: BigNumber;
+        protocolFee: BigNumber;
+      }
+    > {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+    this.assert.common.isNotUndefined(isIssue, 'isIssue arg must be a boolean.');
+
+    return await this.debtIssuanceModuleV2Wrapper.calculateTotalFees(
+      setTokenAddress,
+      quantity,
+      isIssue,
+      callerAddress,
+    );
+  }
+}

--- a/src/api/DebtIssuanceV2API.ts
+++ b/src/api/DebtIssuanceV2API.ts
@@ -27,7 +27,7 @@ import DebtIssuanceModuleV2Wrapper from '../wrappers/set-protocol-v2/DebtIssuanc
 import Assertions from '../assertions';
 
 /**
- * @title  AlmIssuanceAPI
+ * @title  DebtIssuanceV2API
  * @author Set Protocol
  *
  * The DebtIssuanceModuleV2API exposes issue and redeem functionality for Sets that contain poitions that accrue
@@ -37,7 +37,7 @@ import Assertions from '../assertions';
  * in the manager hook, as well as specify issue and redeem fees.
  *
  */
-export default class AlmIssuanceAPI {
+export default class DebtIssuanceV2API {
   private debtIssuanceModuleV2Wrapper: DebtIssuanceModuleV2Wrapper;
   private assert: Assertions;
 
@@ -71,6 +71,7 @@ export default class AlmIssuanceAPI {
   ): Promise<ContractTransaction> {
     this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
     this.assert.schema.isValidAddress('feeRecipient', feeRecipient);
+    this.assert.schema.isValidAddress('managerIssuanceHook', managerIssuanceHook);
 
     return await this.debtIssuanceModuleV2Wrapper.initialize(
       setTokenAddress,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@ import TradeAPI from './TradeAPI';
 import NavIssuanceAPI from './NavIssuanceAPI';
 import PriceOracleAPI from './PriceOracleAPI';
 import DebtIssuanceAPI from './DebtIssuanceAPI';
+import DebtIssuanceV2API from './DebtIssuanceV2API';
 import {
   TradeQuoter,
   CoinGeckoDataService,
@@ -25,6 +26,7 @@ export {
   NavIssuanceAPI,
   PriceOracleAPI,
   DebtIssuanceAPI,
+  DebtIssuanceV2API,
   TradeQuoter,
   CoinGeckoDataService,
   GasOracleService

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -19,6 +19,7 @@ export interface SetJSConfig {
   governanceModuleAddress: Address;
   debtIssuanceModuleAddress: Address;
   zeroExApiKey?: string;
+  debtIssuanceModuleV2Address: Address;
 }
 
 export type SetDetails = {

--- a/src/wrappers/set-protocol-v2/ContractWrapper.ts
+++ b/src/wrappers/set-protocol-v2/ContractWrapper.ts
@@ -339,7 +339,6 @@ export default class ContractWrapper {
     }
   }
 
-
   /**
    * Load DebtIssuanceModule contract
    *

--- a/src/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper.ts
+++ b/src/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper.ts
@@ -1,0 +1,243 @@
+/*
+  Copyright 2021 Set Labs Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Address } from '@setprotocol/set-protocol-v2/dist/utils/types';
+import { ContractTransaction } from 'ethers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { ADDRESS_ZERO } from '@setprotocol/set-protocol-v2/dist/utils/constants';
+import { BigNumber } from 'ethers/lib/ethers';
+import { Provider } from '@ethersproject/providers';
+import { generateTxOpts } from '../../utils/transactions';
+
+import ContractWrapper from './ContractWrapper';
+
+/**
+ * @title  DebtIssuanceModuleV2Wrapper
+ * @author Set Protocol
+ *
+ * The DebtIssuanceModuleV2Wrapper forwards functionality from the DebtIssuanceModuleV2 contract
+ *
+ */
+export default class DebtIssuanceModuleV2Wrapper {
+  private provider: Provider;
+  private contracts: ContractWrapper;
+
+  private debtIssuanceModuleV2Address: Address;
+
+  public constructor(provider: Provider, debtIssuanceModuleV2Address: Address) {
+    this.provider = provider;
+    this.contracts = new ContractWrapper(this.provider);
+    this.debtIssuanceModuleV2Address = debtIssuanceModuleV2Address;
+  }
+
+  /**
+   * Initializes the DebtIssuanceModuleV2 to the SetToken. Only callable by the SetToken's manager.
+   *
+   * @param setTokenAddress             Address of the SetToken to initialize
+   * @param maxManagerFee               Maximum fee that can be charged on issue and redeem
+   * @param managerIssueFee             Fee to charge on issuance
+   * @param managerRedeemFee            Fee to charge on redemption
+   * @param feeRecipient                Address to send fees to
+   * @param managerIssuanceHook         Instance of the Manager Contract with the Pre-Issuance Hook function
+   * @param txOpts                      Overrides for transaction (optional)
+   */
+  public async initialize(
+    setTokenAddress: Address,
+    maxManagerFee: BigNumber,
+    managerIssueFee: BigNumber,
+    managerRedeemFee: BigNumber,
+    feeRecipient: Address,
+    managerIssuanceHook: Address = ADDRESS_ZERO,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const debtIssuanceModuleV2Instance = await this.contracts.loadDebtIssuanceModuleV2Async(
+      this.debtIssuanceModuleV2Address,
+      callerAddress
+    );
+
+    return await debtIssuanceModuleV2Instance.initialize(
+      setTokenAddress,
+      maxManagerFee,
+      managerIssueFee,
+      managerRedeemFee,
+      feeRecipient,
+      managerIssuanceHook,
+      txOptions,
+    );
+  }
+
+  /**
+   * Issue a SetToken from its underlying positions
+   *
+   * @param  setTokenAddress             Address of the SetToken contract to issue
+   * @param  quantity                    Quantity to issue
+   * @param  setTokenRecipientAddress    Address of the recipient of the issued SetToken
+   * @param  callerAddress               Address of caller (optional)
+   * @return                             Transaction hash of the issuance transaction
+   */
+  public async issue(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const debtIssuanceModuleV2Instance = await this.contracts.loadDebtIssuanceModuleV2Async(
+      this.debtIssuanceModuleV2Address,
+      callerAddress
+    );
+
+    return await debtIssuanceModuleV2Instance.issue(
+      setTokenAddress,
+      quantity,
+      setTokenRecipientAddress,
+      txOptions
+    );
+  }
+
+  /**
+   * Redeem a SetToken into its underlying positions
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to redeem
+   * @param  setTokenRecipientAddress  Address of recipient of component tokens from redemption
+   * @param  callerAddress             Address of caller (optional)
+   * @return                           Transaction hash of the redemption transaction
+   */
+  public async redeem(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const debtIssuanceModuleV2Instance = await this.contracts.loadDebtIssuanceModuleV2Async(
+      this.debtIssuanceModuleV2Address,
+      callerAddress
+    );
+
+    return await debtIssuanceModuleV2Instance.redeem(
+      setTokenAddress,
+      quantity,
+      setTokenRecipientAddress,
+      txOptions
+    );
+  }
+
+  /**
+   * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well
+   * as amount of debt that will be returned to caller. Values DO NOT take into account any updates from pre action
+   * manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to issue
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   */
+  public async getRequiredComponentIssuanceUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    const debtIssuanceModuleV2Instance = await this.contracts.loadDebtIssuanceModuleV2Async(
+      this.debtIssuanceModuleV2Address,
+      callerAddress
+    );
+
+    return await debtIssuanceModuleV2Instance.getRequiredComponentIssuanceUnits(
+      setTokenAddress,
+      quantity,
+    );
+  }
+
+  /**
+   * Calculates the amount of each component will be returned on redemption net of fees as well as how much debt needs
+   * to be paid down to redeem. Values DO NOT take into account any updates from pre action manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to redeem
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   */
+  public async getRequiredComponentRedemptionUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    const debtIssuanceModuleV2Instance = await this.contracts.loadDebtIssuanceModuleV2Async(
+      this.debtIssuanceModuleV2Address,
+      callerAddress
+    );
+
+    return await debtIssuanceModuleV2Instance.getRequiredComponentRedemptionUnits(
+      setTokenAddress,
+      quantity,
+    );
+  }
+
+  /**
+   * Calculates the manager fee, protocol fee and resulting totalQuantity to use when calculating unit amounts. If fees
+   * are charged they are added to the total issue quantity, for example 1% fee on 100 Sets means 101 Sets are minted
+   * by caller, the _to address receives 100 and the feeRecipient receives 1. Conversely, on redemption the redeemer
+   * will only receive the collateral that collateralizes 99 Sets, while the additional Set is given to the
+   * feeRecipient.
+   *
+   * @param setTokenAddress  Instance of the SetToken to issue
+   * @param quantity         Amount of SetToken issuer wants to receive/redeem
+   * @param isIssue          If issuing or redeeming
+   * @param callerAddress    Address of caller (optional)
+   *
+   * @return BigNumber       Total amount of Sets to be issued/redeemed with fee adjustment
+   * @return BigNumber       Sets minted to the manager
+   * @return BigNumber       Sets minted to the protocol
+   */
+  public async calculateTotalFees(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    isIssue: boolean,
+    callerAddress: Address = undefined,
+  ): Promise<
+      [BigNumber, BigNumber, BigNumber] & {
+        totalQuantity: BigNumber;
+        managerFee: BigNumber;
+        protocolFee: BigNumber;
+      }
+    > {
+    const debtIssuanceModuleV2Instance = await this.contracts.loadDebtIssuanceModuleV2Async(
+      this.debtIssuanceModuleV2Address,
+      callerAddress
+    );
+
+    return await debtIssuanceModuleV2Instance.calculateTotalFees(
+      setTokenAddress,
+      quantity,
+      isIssue,
+    );
+  }
+}

--- a/test/api/DebtIssuanceV2API.spec.ts
+++ b/test/api/DebtIssuanceV2API.spec.ts
@@ -1,0 +1,361 @@
+/*
+  Copyright 2021 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers, ContractTransaction } from 'ethers';
+import { BigNumber } from 'ethers/lib/ethers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ether } from '@setprotocol/set-protocol-v2/dist/utils/common';
+
+import DebtIssuanceV2API from '@src/api/DebtIssuanceV2API';
+import DebtIssuanceModuleV2Wrapper from '@src/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper';
+import { expect } from '@test/utils/chai';
+
+const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
+
+jest.mock('@src/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper');
+
+describe('DebtIssuanceV2API', () => {
+  let debtIssuanceModuleAddress: Address;
+  let managerIssuanceHook: Address;
+  let setTokenAddress: Address;
+  let owner: Address;
+
+  let debtIssuanceModuleV2Wrapper: DebtIssuanceModuleV2Wrapper;
+  let debtIssuanceV2API: DebtIssuanceV2API;
+
+  beforeEach(async () => {
+    [
+      owner,
+      debtIssuanceModuleAddress,
+      managerIssuanceHook,
+      setTokenAddress,
+    ] = await provider.listAccounts();
+
+    debtIssuanceV2API = new DebtIssuanceV2API(provider, debtIssuanceModuleAddress);
+    debtIssuanceModuleV2Wrapper = (DebtIssuanceModuleV2Wrapper as any).mock.instances[0];
+  });
+
+  afterEach(async () => {
+    (DebtIssuanceModuleV2Wrapper as any).mockClear();
+  });
+
+  describe('#initializeAsync', () => {
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipientAddress: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectCallerAddress: Address;
+
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      subjectSetTokenAddress = setTokenAddress;
+      subjectMaxManagerFee = ether(0.02);
+      subjectManagerIssueFee = ether(0.005);
+      subjectManagerRedeemFee = ether(0.004);
+      subjectFeeRecipientAddress = owner;
+      subjectManagerIssuanceHook = managerIssuanceHook;
+      subjectCallerAddress = owner;
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<any> {
+      return debtIssuanceV2API.initializeAsync(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipientAddress,
+        subjectManagerIssuanceHook,
+        subjectCallerAddress,
+        subjectTransactionOptions,
+      );
+    }
+
+    it('should call initialize on the DebtIssuanceModuleV2Wrapper', async () => {
+      await subject();
+
+      expect(debtIssuanceModuleV2Wrapper.initialize).to.have.beenCalledWith(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipientAddress,
+        subjectManagerIssuanceHook,
+        subjectCallerAddress,
+        subjectTransactionOptions,
+      );
+    });
+  });
+
+  describe('#issueAsync', () => {
+    let subjectSetTokenAddress: Address;
+    let subjectIssuanceQuantity: BigNumber;
+    let subjectSetTokenRecipientAddress: Address;
+    let subjectCallerAddress: Address;
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      subjectSetTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      subjectIssuanceQuantity = ether(1);
+      subjectSetTokenRecipientAddress = '0x0872262A92581EC09C2d522b48bCcd9E3C8ACf9C';
+      subjectCallerAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return await debtIssuanceV2API.issueAsync(
+        subjectSetTokenAddress,
+        subjectIssuanceQuantity,
+        subjectSetTokenRecipientAddress,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    }
+
+    it('should call issue with correct params', async () => {
+      await subject();
+
+      expect(debtIssuanceModuleV2Wrapper.issue).to.have.beenCalledWith(
+        subjectSetTokenAddress,
+        subjectIssuanceQuantity,
+        subjectSetTokenRecipientAddress,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectSetTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when the SetToken recipient address is invalid', () => {
+      beforeEach(async () => {
+        subjectSetTokenRecipientAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#redeemAsync', () => {
+    let subjectSetTokenAddress: Address;
+    let subjectRedemptionQuantity: BigNumber;
+    let subjectRecipientAddress: Address;
+    let subjectCallerAddress: Address;
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      subjectSetTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      subjectRedemptionQuantity = ether(1);
+      subjectRecipientAddress = '0x0872262A92581EC09C2d522b48bCcd9E3C8ACf9C';
+      subjectCallerAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return await debtIssuanceV2API.redeemAsync(
+        subjectSetTokenAddress,
+        subjectRedemptionQuantity,
+        subjectRecipientAddress,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    }
+
+    it('should call issue with correct params', async () => {
+      await subject();
+
+      expect(debtIssuanceModuleV2Wrapper.redeem).to.have.beenCalledWith(
+        subjectSetTokenAddress,
+        subjectRedemptionQuantity,
+        subjectRecipientAddress,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectSetTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when the recipient address is invalid', () => {
+      beforeEach(async () => {
+        subjectRecipientAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getRequiredComponentIssuanceUnits', () => {
+    let subjectSetTokenAddress: Address;
+    let subjectIssuanceQuantity: BigNumber;
+    let subjectCallerAddress: Address;
+
+    beforeEach(async () => {
+      subjectSetTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      subjectIssuanceQuantity = ether(1);
+      subjectCallerAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      return await debtIssuanceV2API.getRequiredComponentIssuanceUnits(
+        subjectSetTokenAddress,
+        subjectIssuanceQuantity,
+        subjectCallerAddress,
+      );
+    }
+
+    it('should call getRequiredComponentIssuanceUnits with correct params', async () => {
+      await subject();
+
+      expect(debtIssuanceModuleV2Wrapper.getRequiredComponentIssuanceUnits).to.have.beenCalledWith(
+        subjectSetTokenAddress,
+        subjectIssuanceQuantity,
+        subjectCallerAddress,
+      );
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectSetTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getRequiredComponentRedemptionUnits', () => {
+    let subjectSetTokenAddress: Address;
+    let subjectRedemptionQuantity: BigNumber;
+    let subjectCallerAddress: Address;
+
+    beforeEach(async () => {
+      subjectSetTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      subjectRedemptionQuantity = ether(1);
+      subjectCallerAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      return await debtIssuanceV2API.getRequiredComponentRedemptionUnits(
+        subjectSetTokenAddress,
+        subjectRedemptionQuantity,
+        subjectCallerAddress,
+      );
+    }
+
+    it('should call getRequiredComponentRedemptionUnits with correct params', async () => {
+      await subject();
+
+      expect(debtIssuanceModuleV2Wrapper.getRequiredComponentRedemptionUnits).to.have.beenCalledWith(
+        subjectSetTokenAddress,
+        subjectRedemptionQuantity,
+        subjectCallerAddress,
+      );
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectSetTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#calculateTotalFeesAsync', () => {
+    let subjectSetTokenAddress: Address;
+    let subjectQuantity: BigNumber;
+    let subjectIsIssue: boolean;
+    let subjectCallerAddress: Address;
+
+    beforeEach(async () => {
+      subjectSetTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      subjectQuantity = ether(1);
+      subjectIsIssue = true;
+      subjectCallerAddress = '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16';
+    });
+
+    async function subject(): Promise<
+      [BigNumber, BigNumber, BigNumber] & {
+        totalQuantity: BigNumber;
+        managerFee: BigNumber;
+        protocolFee: BigNumber;
+      }
+    > {
+      return await debtIssuanceV2API.calculateTotalFeesAsync(
+        subjectSetTokenAddress,
+        subjectQuantity,
+        subjectIsIssue,
+        subjectCallerAddress,
+      );
+    }
+
+    it('should call calculateTotalFeesAsync with correct params', async () => {
+      await subject();
+
+      expect(debtIssuanceModuleV2Wrapper.calculateTotalFees).to.have.beenCalledWith(
+        subjectSetTokenAddress,
+        subjectQuantity,
+        subjectIsIssue,
+        subjectCallerAddress,
+      );
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectSetTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when isIssue is undefined', () => {
+      beforeEach(async () => {
+        subjectIsIssue = undefined;
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('isIssue arg must be a boolean.');
+      });
+    });
+  });
+});

--- a/test/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper.spec.ts
+++ b/test/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper.spec.ts
@@ -1,0 +1,641 @@
+import { ethers, ContractTransaction } from 'ethers';
+import { BigNumber } from 'ethers/lib/ethers';
+
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ADDRESS_ZERO, ZERO } from '@setprotocol/set-protocol-v2/dist/utils/constants';
+import {
+  Blockchain,
+  ether,
+  bitcoin,
+  preciseMul,
+  preciseMulCeil,
+} from '@setprotocol/set-protocol-v2/dist/utils/common';
+import DeployHelper from '@setprotocol/set-protocol-v2/dist/utils/deploys';
+import { SystemFixture } from '@setprotocol/set-protocol-v2/dist/utils/fixtures/systemFixture';
+import {
+  DebtIssuanceModuleV2,
+  SetToken,
+} from '@setprotocol/set-protocol-v2/dist/utils/contracts';
+
+import DebtIssuanceModuleV2Wrapper from '@src/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper';
+import { expect } from '../../utils/chai';
+
+const provider = new ethers.providers.JsonRpcProvider();
+const blockchain = new Blockchain(provider);
+
+describe('DebtIssuanceModuleV2Wrapper', () => {
+  let owner: Address;
+  let recipient: Address;
+  let functionCaller: Address;
+  let randomAddress: Address;
+
+  let debtIssuanceModuleV2Wrapper: DebtIssuanceModuleV2Wrapper;
+  let debtIssuanceModuleV2: DebtIssuanceModuleV2;
+
+  let deployer: DeployHelper;
+  let setup: SystemFixture;
+
+  beforeAll(async() => {
+    [
+      owner,
+      recipient,
+      functionCaller,
+      randomAddress,
+    ] = await provider.listAccounts();
+
+    deployer = new DeployHelper(provider.getSigner(owner));
+    setup = new SystemFixture(provider, owner);
+  });
+
+  beforeEach(async () => {
+    await blockchain.saveSnapshotAsync();
+
+    await setup.initialize();
+
+    debtIssuanceModuleV2 = await deployer.modules.deployDebtIssuanceModuleV2(setup.controller.address);
+    await setup.controller.addModule(debtIssuanceModuleV2.address);
+
+    debtIssuanceModuleV2Wrapper = new DebtIssuanceModuleV2Wrapper(provider, debtIssuanceModuleV2.address);
+  });
+
+  afterEach(async () => {
+    await blockchain.revertAsync();
+  });
+
+  describe('#initialize', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectCaller: Address;
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address],
+        [ether(1)],
+        [debtIssuanceModuleV2.address]
+      );
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(0.02);
+      subjectManagerIssueFee = ether(0.005);
+      subjectManagerRedeemFee = ether(0.004);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = randomAddress;
+      subjectCaller = owner;
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<any> {
+      debtIssuanceModuleV2 = debtIssuanceModuleV2.connect(provider.getSigner(subjectCaller));
+      return debtIssuanceModuleV2Wrapper.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+        subjectCaller,
+        subjectTransactionOptions,
+      );
+    }
+
+    it('should enable the module on the SetToken', async () => {
+      await subject();
+      const isModuleEnabled = await setToken.isInitializedModule(debtIssuanceModuleV2.address);
+      expect(isModuleEnabled).to.eq(true);
+    });
+
+    it('should properly set the manager issuance hooks', async () => {
+      await subject();
+      const issuanceSettings = await debtIssuanceModuleV2.issuanceSettings(subjectSetTokenAddress);
+      const managerIssuanceHook = issuanceSettings.managerIssuanceHook;
+      expect(managerIssuanceHook).to.eq(subjectManagerIssuanceHook);
+    });
+
+    describe('when the issue fee is greater than the maximum fee', () => {
+      beforeEach(async () => {
+        subjectManagerIssueFee = ether(0.03);
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Issue fee can\'t exceed maximum fee');
+      });
+    });
+
+    describe('when the redeem fee is greater than the maximum fee', () => {
+      beforeEach(async () => {
+        subjectManagerRedeemFee = ether(0.03);
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Redeem fee can\'t exceed maximum fee');
+      });
+    });
+
+    describe('when the caller is not the SetToken manager', () => {
+      beforeEach(async () => {
+        subjectCaller = randomAddress;
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Must be the SetToken manager');
+      });
+    });
+
+    describe('when SetToken is not in pending state', () => {
+      beforeEach(async () => {
+        const newModule = randomAddress;
+        await setup.controller.addModule(newModule);
+
+        const debtIssuanceModuleNotPendingSetToken = await setup.createSetToken(
+          [setup.weth.address],
+          [ether(1)],
+          [newModule]
+        );
+
+        subjectSetTokenAddress = debtIssuanceModuleNotPendingSetToken.address;
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Must be pending initialization');
+      });
+    });
+
+    describe('when the SetToken is not enabled on the controller', () => {
+      beforeEach(async () => {
+        const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
+          [setup.weth.address],
+          [ether(1)],
+          [debtIssuanceModuleV2.address]
+        );
+
+        subjectSetTokenAddress = nonEnabledSetToken.address;
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Must be controller-enabled SetToken');
+      });
+    });
+  });
+
+  describe('#issue', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectIssuanceQuantity: BigNumber;
+    let subjectIssueTo: Address;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [debtIssuanceModuleV2.address]
+      );
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(0.02);
+      subjectManagerIssueFee = ether(0.005);
+      subjectManagerRedeemFee = ether(0.004);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectIssuanceQuantity = ether(2);
+      subjectIssueTo = functionCaller;
+      subjectCaller = owner;
+
+      await debtIssuanceModuleV2.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      // Approve tokens to the issuance module
+      await setup.weth.approve(debtIssuanceModuleV2.address, ether(5));
+      await setup.wbtc.approve(debtIssuanceModuleV2.address, bitcoin(10));
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return debtIssuanceModuleV2Wrapper.issue(
+        subjectSetTokenAddress,
+        subjectIssuanceQuantity,
+        subjectIssueTo,
+        subjectCaller
+      );
+    }
+
+    it('should issue the correct quantity of SetToken for the issue to address', async () => {
+      const existingBalance = await setToken.balanceOf(functionCaller);
+      expect(existingBalance.toString()).to.be.eq(ZERO.toString());
+
+      await subject();
+      const newBalance = await setToken.balanceOf(functionCaller);
+      expect(newBalance.toString()).to.equal(subjectIssuanceQuantity.toString());
+    });
+  });
+
+  describe('#redeem', () => {
+    let setToken: SetToken;
+    let issuanceQuantity: BigNumber;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectRedeemQuantity: BigNumber;
+    let subjectRedeemTo: Address;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [debtIssuanceModuleV2.address]
+      );
+      issuanceQuantity = ether(2);
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(0.02);
+      subjectManagerIssueFee = ether(0.005);
+      subjectManagerRedeemFee = ether(0.004);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectRedeemQuantity = ether(2);
+      subjectRedeemTo = recipient;
+      subjectCaller = functionCaller;
+
+      await debtIssuanceModuleV2.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      // Approve tokens to the issuance module
+      await setup.weth.approve(debtIssuanceModuleV2.address, ether(5));
+      await setup.wbtc.approve(debtIssuanceModuleV2.address, bitcoin(10));
+
+      await debtIssuanceModuleV2.issue(setToken.address, issuanceQuantity, functionCaller);
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return debtIssuanceModuleV2Wrapper.redeem(
+        subjectSetTokenAddress,
+        subjectRedeemQuantity,
+        subjectRedeemTo,
+        subjectCaller
+      );
+    }
+
+    it('should redeem the correct quantity of SetTokens for the caller', async () => {
+      const existingBalance = await setToken.balanceOf(subjectCaller);
+      expect(existingBalance.toString()).to.be.eq(issuanceQuantity.toString());
+
+      await subject();
+
+      const newBalance = await setToken.balanceOf(subjectCaller);
+      const expectedNewBalance = issuanceQuantity.sub(subjectRedeemQuantity).toString();
+      expect(newBalance.toString()).to.equal(expectedNewBalance);
+    });
+
+    describe('when the redeem quantity is higher than the caller owns', () => {
+      beforeEach(() => {
+        subjectRedeemQuantity = ether(3);
+      });
+
+      it('should revert', async () => {
+        try {
+          await subject();
+        } catch (err) {
+          expect(err.body).to.include(
+            'ERC20: burn amount exceeds balance'
+          );
+        }
+      });
+    });
+  });
+
+  describe('#getRequiredComponentIssuanceUnits', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectIssuanceQuantity: BigNumber;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [debtIssuanceModuleV2.address]
+      );
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(1);
+      subjectManagerIssueFee = ether(0);
+      subjectManagerRedeemFee = ether(0);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectIssuanceQuantity = ether(2);
+      subjectCaller = functionCaller;
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      await debtIssuanceModuleV2.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      return debtIssuanceModuleV2Wrapper.getRequiredComponentIssuanceUnits(
+        subjectSetTokenAddress,
+        subjectIssuanceQuantity,
+        subjectCaller
+      );
+    }
+
+    it('should return the correct required quantity of component tokens for issuing', async () => {
+      const [components, equityFlows, debtFlows] = await subject();
+      const wethFlows = preciseMul(subjectIssuanceQuantity, ether(1));
+      const wbtcFlows = preciseMulCeil(subjectIssuanceQuantity, bitcoin(2));
+
+      const expectedComponents = await setToken.getComponents();
+      const expectedEquityFlows = [wethFlows, wbtcFlows];
+      const expectedDebtFlows = [ZERO, ZERO];
+
+      expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+      expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+      expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+    });
+
+    describe('when there\'s an issuance fee', () => {
+      beforeEach(() => {
+        subjectManagerIssueFee = ether(0.01);
+      });
+
+      it('should return required amount with fee', async () => {
+        const [components, equityFlows, debtFlows] = await subject();
+        const mintQuantity = preciseMul(subjectIssuanceQuantity, ether(1).add(subjectManagerIssueFee));
+        const wethFlows = preciseMul(mintQuantity, ether(1));
+        const wbtcFlows = preciseMulCeil(mintQuantity, bitcoin(2));
+
+        const expectedComponents = await setToken.getComponents();
+        const expectedEquityFlows = [wethFlows, wbtcFlows];
+        const expectedDebtFlows = [ZERO, ZERO];
+
+        expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+        expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+        expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+      });
+    });
+
+    describe('when a few blocks mine and interest accrues', async () => {
+      beforeEach(() => {
+        blockchain.waitBlocksAsync(100);
+      });
+
+      it('should return the correct required quantity after syncing', async () => {
+        const [components, equityFlows, debtFlows] = await subject();
+        const wethFlows = preciseMul(subjectIssuanceQuantity, ether(1));
+        const wbtcFlows = preciseMulCeil(subjectIssuanceQuantity, bitcoin(2));
+
+        const expectedComponents = await setToken.getComponents();
+        const expectedEquityFlows = [wethFlows, wbtcFlows];
+        const expectedDebtFlows = [ZERO, ZERO];
+
+        expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+        expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+        expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+      });
+    });
+  });
+
+  describe('#getRequiredComponentRedemptionUnits', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectRedemptionQuantity: BigNumber;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [debtIssuanceModuleV2.address]
+      );
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(1);
+      subjectManagerIssueFee = ether(0);
+      subjectManagerRedeemFee = ether(0);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectRedemptionQuantity = ether(2);
+      subjectCaller = functionCaller;
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      await debtIssuanceModuleV2.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      return debtIssuanceModuleV2Wrapper.getRequiredComponentRedemptionUnits(
+        subjectSetTokenAddress,
+        subjectRedemptionQuantity,
+        subjectCaller
+      );
+    }
+
+    it('should return the correct required quantity of component tokens for redeeming', async () => {
+      const [components, equityFlows, debtFlows] = await subject();
+      const wethFlows = preciseMul(subjectRedemptionQuantity, ether(1));
+      const wbtcFlows = preciseMulCeil(subjectRedemptionQuantity, bitcoin(2));
+
+      const expectedComponents = await setToken.getComponents();
+      const expectedEquityFlows = [wethFlows, wbtcFlows];
+      const expectedDebtFlows = [ZERO, ZERO];
+
+      expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+      expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+      expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+    });
+
+    describe('when there\'s a redemption fee', () => {
+      beforeEach(() => {
+        subjectManagerRedeemFee = ether(0.01);
+      });
+
+      it('should return required amount with fee', async () => {
+        const [components, equityFlows, debtFlows] = await subject();
+        const mintQuantity = preciseMul(subjectRedemptionQuantity, ether(1).sub(subjectManagerRedeemFee));
+        const wethFlows = preciseMul(mintQuantity, ether(1));
+        const wbtcFlows = preciseMulCeil(mintQuantity, bitcoin(2));
+
+        const expectedComponents = await setToken.getComponents();
+        const expectedEquityFlows = [wethFlows, wbtcFlows];
+        const expectedDebtFlows = [ZERO, ZERO];
+
+        expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+        expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+        expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+      });
+    });
+  });
+
+  describe('#calculateTotalFees', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectQuantity: BigNumber;
+    let subjectIsIssue: boolean;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [debtIssuanceModuleV2.address]
+      );
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(1);
+      subjectManagerIssueFee = ether(0);
+      subjectManagerRedeemFee = ether(0);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectQuantity = ether(2);
+      subjectCaller = functionCaller;
+    });
+
+    async function subject(): Promise<
+      [BigNumber, BigNumber, BigNumber] & {
+        totalQuantity: BigNumber;
+        managerFee: BigNumber;
+        protocolFee: BigNumber;
+      }
+    > {
+      await debtIssuanceModuleV2.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      return debtIssuanceModuleV2Wrapper.calculateTotalFees(
+        subjectSetTokenAddress,
+        subjectQuantity,
+        subjectIsIssue,
+        subjectCaller
+      );
+    }
+    describe('when calculateTotalFees is used for issuance with no issue fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = true;
+      });
+
+      it('should return no issue fee value', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = subjectQuantity;
+        const expectedManagerFeeAmount = ether(0);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+
+    describe('when there\'s an issue fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = true;
+        subjectManagerIssueFee = ether(0.01);
+      });
+
+      it('should return required amount with issue fee', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = preciseMul(subjectQuantity, ether(1).add(subjectManagerIssueFee));
+        const expectedManagerFeeAmount = preciseMul(subjectQuantity, subjectManagerIssueFee);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+
+    describe('when calculateTotalFees is used for redemption with no redeem fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = false;
+      });
+
+      it('should return no redeem fee value', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = subjectQuantity;
+        const expectedManagerFeeAmount = ether(0);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+
+    describe('when there\'s a redeem fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = false;
+        subjectManagerRedeemFee = ether(0.01);
+      });
+
+      it('should return required amount with redeem fee', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = preciseMul(subjectQuantity, ether(1).sub(subjectManagerRedeemFee));
+        const expectedManagerFeeAmount = preciseMul(subjectQuantity, subjectManagerRedeemFee);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,10 +849,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@setprotocol/set-protocol-v2@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.1.tgz#26eb788f9ff1a2fe98e36951c21778b6f261d0cd"
-  integrity sha512-ZXCDdJjIP1/kqFbcKOESU4vu7SnF5mZVR4/7S61zN/NMRsnmo/6Udzno63igHVbFxpXuScYMQ3+PqtawJ0bm1g==
+"@setprotocol/set-protocol-v2@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.2.tgz#c88f3e3d4a3e059a543b221ab572b138ca4fc0f4"
+  integrity sha512-ZwvngLyQs7WXTENAA5Dx4UBI+gBlLsL+Hp192cUhuRcMmPCCxMpKTgj5ORu3iHk80NzlNHQ+U88+4BpbSScMjA==
   dependencies:
     ethers "^5.4.6"
     fs-extra "^5.0.0"


### PR DESCRIPTION
Plus test cases (for accruing interest after blocks have passed) and package bump for updated set-protocol-v2 contract