### PR TITLE
Add SlippageIssuanceModuleWrapper class and tests

### DIFF
--- a/src/api/SlippageIssuanceAPI.ts
+++ b/src/api/SlippageIssuanceAPI.ts
@@ -1,0 +1,238 @@
+/*
+  Copyright 2021 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { ContractTransaction } from 'ethers';
+import { Provider } from '@ethersproject/providers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ADDRESS_ZERO } from '@setprotocol/set-protocol-v2/dist/utils/constants';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { BigNumber } from 'ethers/lib/ethers';
+
+import DebtIssuanceModuleV2Wrapper from '../wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper';
+import Assertions from '../assertions';
+
+/**
+ * @title  DebtIssuanceV2API
+ * @author Set Protocol
+ *
+ * The DebtIssuanceModuleV2API exposes issue and redeem functionality for Sets that contain poitions that accrue
+ * interest per block. The getter function syncs the position balance to the current block, so subsequent blocks
+ * will cause the position value to be slightly out of sync (a buffer is needed). This API is primarily used for Sets
+ * that rely on the ALM contracts to manage debt. The manager can define arbitrary issuance logic
+ * in the manager hook, as well as specify issue and redeem fees.
+ *
+ */
+export default class DebtIssuanceV2API {
+  private debtIssuanceModuleV2Wrapper: DebtIssuanceModuleV2Wrapper;
+  private assert: Assertions;
+
+  public constructor(provider: Provider, debtIssuanceModuleV2Address: Address, assertions?: Assertions) {
+    this.debtIssuanceModuleV2Wrapper = new DebtIssuanceModuleV2Wrapper(provider, debtIssuanceModuleV2Address);
+    this.assert = assertions || new Assertions();
+  }
+
+  /**
+   * Initializes the DebtIssuanceModuleV2 to the SetToken. Only callable by the SetToken's manager.
+   *
+   * @param setTokenAddress             Address of the SetToken to initialize
+   * @param maxManagerFee               Maximum fee that can be charged on issue and redeem
+   * @param managerIssueFee             Fee to charge on issuance
+   * @param managerRedeemFee            Fee to charge on redemption
+   * @param feeRecipient                Address to send fees to
+   * @param managerIssuanceHook         Instance of the Manager Contract with the Pre-Issuance Hook function
+   * @param txOpts                      Overrides for transaction (optional)
+   *
+   * @return                            Transaction hash of the initialize transaction
+   */
+  public async initializeAsync(
+    setTokenAddress: Address,
+    maxManagerFee: BigNumber,
+    managerIssueFee: BigNumber,
+    managerRedeemFee: BigNumber,
+    feeRecipient: Address,
+    managerIssuanceHook: Address = ADDRESS_ZERO,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('feeRecipient', feeRecipient);
+    this.assert.schema.isValidAddress('managerIssuanceHook', managerIssuanceHook);
+
+    return await this.debtIssuanceModuleV2Wrapper.initialize(
+      setTokenAddress,
+      maxManagerFee,
+      managerIssueFee,
+      managerRedeemFee,
+      feeRecipient,
+      managerIssuanceHook,
+      callerAddress,
+      txOpts,
+    );
+  }
+
+  /**
+   * Issue a SetToken from its underlying positions
+   *
+   * @param  setTokenAddress             Address of the SetToken contract to issue
+   * @param  quantity                    Quantity to issue
+   * @param  setTokenRecipientAddress    Address of the recipient of the issued SetToken
+   * @param  callerAddress               Address of caller (optional)
+   * @return                             Transaction hash of the issuance transaction
+   */
+  public async issueAsync(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('setTokenRecipientAddress', setTokenRecipientAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.issue(
+      setTokenAddress,
+      quantity,
+      setTokenRecipientAddress,
+      callerAddress,
+      txOpts
+    );
+  }
+
+  /**
+   * Redeem a SetToken into its underlying positions
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to redeem
+   * @param  setTokenRecipientAddress  Address of recipient of component tokens from redemption
+   * @param  callerAddress             Address of caller (optional)
+   * @return                           Transaction hash of the redemption transaction
+   */
+  public async redeemAsync(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('setTokenRecipientAddress', setTokenRecipientAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.redeem(
+      setTokenAddress,
+      quantity,
+      setTokenRecipientAddress,
+      callerAddress,
+      txOpts
+    );
+  }
+
+  /**
+   * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well
+   * as amount of debt that will be returned to caller. Values DO NOT take into account any updates from pre action
+   * manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to issue
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   */
+  public async getRequiredComponentIssuanceUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.getRequiredComponentIssuanceUnits(
+      setTokenAddress,
+      quantity,
+      callerAddress,
+    );
+  }
+
+  /**
+   * Calculates the amount of each component will be returned on redemption net of fees as well as how much debt needs
+   * to be paid down to redeem. Values DO NOT take into account any updates from pre action manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to redeem
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   */
+  public async getRequiredComponentRedemptionUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+
+    return await this.debtIssuanceModuleV2Wrapper.getRequiredComponentRedemptionUnits(
+      setTokenAddress,
+      quantity,
+      callerAddress,
+    );
+  }
+
+  /**
+   * Calculates the manager fee, protocol fee and resulting totalQuantity to use when calculating unit amounts. If fees
+   * are charged they are added to the total issue quantity, for example 1% fee on 100 Sets means 101 Sets are minted
+   * by caller, the _to address receives 100 and the feeRecipient receives 1. Conversely, on redemption the redeemer
+   * will only receive the collateral that collateralizes 99 Sets, while the additional Set is given to the
+   * feeRecipient.
+   *
+   * @param setTokenAddress  Instance of the SetToken to issue
+   * @param quantity         Amount of SetToken issuer wants to receive/redeem
+   * @param isIssue          If issuing or redeeming
+   *
+   * @return BigNumber       Total amount of Sets to be issued/redeemed with fee adjustment
+   * @return BigNumber       Sets minted to the manager
+   * @return BigNumber       Sets minted to the protocol
+   */
+  public async calculateTotalFeesAsync(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    isIssue: boolean,
+    callerAddress: Address = undefined,
+  ): Promise<
+      [BigNumber, BigNumber, BigNumber] & {
+        totalQuantity: BigNumber;
+        managerFee: BigNumber;
+        protocolFee: BigNumber;
+      }
+    > {
+    this.assert.schema.isValidAddress('setAddress', setTokenAddress);
+    this.assert.common.isNotUndefined(isIssue, 'isIssue arg must be a boolean.');
+
+    return await this.debtIssuanceModuleV2Wrapper.calculateTotalFees(
+      setTokenAddress,
+      quantity,
+      isIssue,
+      callerAddress,
+    );
+  }
+}

--- a/src/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.ts
+++ b/src/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.ts
@@ -1,0 +1,270 @@
+/*
+  Copyright 2021 Set Labs Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Address } from '@setprotocol/set-protocol-v2/dist/utils/types';
+import { ContractTransaction } from 'ethers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { ADDRESS_ZERO } from '@setprotocol/set-protocol-v2/dist/utils/constants';
+import { BigNumber } from 'ethers/lib/ethers';
+import { Provider } from '@ethersproject/providers';
+import { generateTxOpts } from '../../utils/transactions';
+
+import ContractWrapper from './ContractWrapper';
+
+/**
+ * @title  SlippageIssuanceModuleV2Wrapper
+ * @author Set Protocol
+ *
+ * The SlippageIssuanceModuleV2Wrapper forwards functionality from the SlippageIssuanceModule contract
+ *
+ */
+export default class SlippageIssuanceModuleV2Wrapper {
+  private provider: Provider;
+  private contracts: ContractWrapper;
+
+  private slippageIssuanceModuleAddress: Address;
+
+  public constructor(provider: Provider, slippageIssuanceModuleAddress: Address) {
+    this.provider = provider;
+    this.contracts = new ContractWrapper(this.provider);
+    this.slippageIssuanceModuleAddress = slippageIssuanceModuleAddress;
+  }
+
+  /**
+   * Initializes the SlippageIssuanceModule to the SetToken. Only callable by the SetToken's manager.
+   *
+   * @param setTokenAddress             Address of the SetToken to initialize
+   * @param maxManagerFee               Maximum fee that can be charged on issue and redeem
+   * @param managerIssueFee             Fee to charge on issuance
+   * @param managerRedeemFee            Fee to charge on redemption
+   * @param feeRecipient                Address to send fees to
+   * @param managerIssuanceHook         Instance of the Manager Contract with the Pre-Issuance Hook function
+   * @param txOpts                      Overrides for transaction (optional)
+   */
+  public async initialize(
+    setTokenAddress: Address,
+    maxManagerFee: BigNumber,
+    managerIssueFee: BigNumber,
+    managerRedeemFee: BigNumber,
+    feeRecipient: Address,
+    managerIssuanceHook: Address = ADDRESS_ZERO,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const slippageIssuanceModuleInstance = await this.contracts.loadSlippageIssuanceModuleAsync(
+      this.slippageIssuanceModuleAddress,
+      callerAddress
+    );
+
+    return await slippageIssuanceModuleInstance.initialize(
+      setTokenAddress,
+      maxManagerFee,
+      managerIssueFee,
+      managerRedeemFee,
+      feeRecipient,
+      managerIssuanceHook,
+      txOptions,
+    );
+  }
+
+  /**
+   * Deposits components to the SetToken, replicates any external module component positions and mints
+   * the SetToken. If the token has a debt position all collateral will be transferred in first then debt
+   * will be returned to the minting address. If specified, a fee will be charged on issuance. Issuer can
+   * also pass in a max amount of tokens they are willing to pay for each component. They are NOT required
+   * to pass in a limit for every component, and may in fact only want to pass in limits for components which
+   * incur slippage to replicate (i.e. perpetuals). Passing in empty arrays for _checkComponents and
+   * _maxTokenAmountsIn is equivalent to calling issue. NOTE: not passing in limits for positions that require
+   * a trade for replication leaves the issuer open to sandwich attacks!
+   *
+   * @param setTokenAddress             Instance of the SetToken to issue
+   * @param quantity                    Quantity of SetToken to issue
+   * @param checkedComponents           Array of components to be checked to verify required collateral doesn't exceed
+   *                                      defined max. Each entry must be unique.
+   * @param maxTokenAmountsIn           Maps to same index in _checkedComponents. Max amount of component willing to
+   *                                      transfer in to collateralize _setQuantity amount of _setToken.
+   * @param setTokenRecipientAddress    Address to mint SetToken to
+   */
+  public async issueWithSlippage(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    checkedComponents: Address[],
+    maxTokenAmountsIn: BigNumber[],
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const slippageIssuanceModuleInstance = await this.contracts.loadSlippageIssuanceModuleAsync(
+      this.slippageIssuanceModuleAddress,
+      callerAddress
+    );
+
+    return await slippageIssuanceModuleInstance.issueWithSlippage(
+      setTokenAddress,
+      quantity,
+      checkedComponents,
+      maxTokenAmountsIn,
+      setTokenRecipientAddress,
+      txOptions
+    );
+  }
+
+  /**
+   * Returns components from the SetToken, unwinds any external module component positions and burns the SetToken.
+   * If the token has debt positions, the module transfers in the required debt amounts from the caller and uses
+   * those funds to repay the debts on behalf of the SetToken. All debt will be paid down first then equity positions
+   * will be returned to the minting address. If specified, a fee will be charged on redeem. Redeemer can
+   * also pass in a min amount of tokens they want to receive for each component. They are NOT required
+   * to pass in a limit for every component, and may in fact only want to pass in limits for components which
+   * incur slippage to replicate (i.e. perpetuals). Passing in empty arrays for _checkComponents and
+   * _minTokenAmountsOut is equivalent to calling redeem. NOTE: not passing in limits for positions that require
+   * a trade for replication leaves the redeemer open to sandwich attacks!
+   *
+   * @param setTokenAddress             Instance of the SetToken to redeem
+   * @param quantity                    Quantity of SetToken to redeem
+   * @param checkedComponents           Array of components to be checked to verify received collateral isn't less
+   *                                      than defined min. Each entry must be unique.
+   * @param minTokenAmountsOut          Maps to same index in _checkedComponents. Min amount of component willing to
+   *                                      receive to redeem _setQuantity amount of _setToken.
+   * @param setTokenRecipientAddress    Address to send collateral to
+   */
+  public async redeemWithSlippage(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    checkedComponents: Address[],
+    minTokenAmountsOut: BigNumber[],
+    setTokenRecipientAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const slippageIssuanceModuleInstance = await this.contracts.loadSlippageIssuanceModuleAsync(
+      this.slippageIssuanceModuleAddress,
+      callerAddress
+    );
+
+    return await slippageIssuanceModuleInstance.redeemWithSlippage(
+      setTokenAddress,
+      quantity,
+      checkedComponents,
+      minTokenAmountsOut,
+      setTokenRecipientAddress,
+      txOptions
+    );
+  }
+
+  /**
+   * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well
+   * as amount of debt that will be returned to caller. Values DO NOT take into account any updates from pre action
+   * manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to issue
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented
+   *                                   as a BigNumber
+   */
+  public async getRequiredComponentIssuanceUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    const slippageIssuanceModuleInstance = await this.contracts.loadSlippageIssuanceModuleAsync(
+      this.slippageIssuanceModuleAddress,
+      callerAddress
+    );
+
+    return await slippageIssuanceModuleInstance.getRequiredComponentIssuanceUnits(
+      setTokenAddress,
+      quantity,
+    );
+  }
+
+  /**
+   * Calculates the amount of each component will be returned on redemption net of fees as well as how much debt needs
+   * to be paid down to redeem. Values DO NOT take into account any updates from pre action manager or module hooks.
+   *
+   * @param  setTokenAddress           Address of the SetToken contract
+   * @param  quantity                  Quantity to redeem
+   * @param  callerAddress             Address of caller (optional)
+   *
+   * @return address[]                 Array of component addresses making up the Set
+   * @return BigNumber[]               Array of equity notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   * @return BigNumber[]               Array of debt notional amounts of each component, respectively, represented as
+   *                                   a BigNumber
+   */
+  public async getRequiredComponentRedemptionUnits(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    const slippageIssuanceModuleInstance = await this.contracts.loadSlippageIssuanceModuleAsync(
+      this.slippageIssuanceModuleAddress,
+      callerAddress
+    );
+
+    return await slippageIssuanceModuleInstance.getRequiredComponentRedemptionUnits(
+      setTokenAddress,
+      quantity,
+    );
+  }
+
+  /**
+   * Calculates the manager fee, protocol fee and resulting totalQuantity to use when calculating unit amounts. If fees
+   * are charged they are added to the total issue quantity, for example 1% fee on 100 Sets means 101 Sets are minted
+   * by caller, the _to address receives 100 and the feeRecipient receives 1. Conversely, on redemption the redeemer
+   * will only receive the collateral that collateralizes 99 Sets, while the additional Set is given to the
+   * feeRecipient.
+   *
+   * @param setTokenAddress  Instance of the SetToken to issue
+   * @param quantity         Amount of SetToken issuer wants to receive/redeem
+   * @param isIssue          If issuing or redeeming
+   * @param callerAddress    Address of caller (optional)
+   *
+   * @return BigNumber       Total amount of Sets to be issued/redeemed with fee adjustment
+   * @return BigNumber       Sets minted to the manager
+   * @return BigNumber       Sets minted to the protocol
+   */
+  public async calculateTotalFees(
+    setTokenAddress: Address,
+    quantity: BigNumber,
+    isIssue: boolean,
+    callerAddress: Address = undefined,
+  ): Promise<
+      [BigNumber, BigNumber, BigNumber] & {
+        totalQuantity: BigNumber;
+        managerFee: BigNumber;
+        protocolFee: BigNumber;
+      }
+    > {
+    const slippageIssuanceModuleInstance = await this.contracts.loadSlippageIssuanceModuleAsync(
+      this.slippageIssuanceModuleAddress,
+      callerAddress
+    );
+
+    return await slippageIssuanceModuleInstance.calculateTotalFees(
+      setTokenAddress,
+      quantity,
+      isIssue,
+    );
+  }
+}

--- a/test/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.spec.ts
+++ b/test/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.spec.ts
@@ -1,0 +1,654 @@
+import { ethers, ContractTransaction } from 'ethers';
+import { BigNumber } from 'ethers/lib/ethers';
+
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ADDRESS_ZERO, ZERO } from '@setprotocol/set-protocol-v2/dist/utils/constants';
+import {
+  Blockchain,
+  ether,
+  bitcoin,
+  preciseMul,
+  preciseMulCeil,
+} from '@setprotocol/set-protocol-v2/dist/utils/common';
+import DeployHelper from '@setprotocol/set-protocol-v2/dist/utils/deploys';
+import { SystemFixture } from '@setprotocol/set-protocol-v2/dist/utils/fixtures/systemFixture';
+import {
+  SlippageIssuanceModule,
+  DebtModuleMock,
+  ModuleIssuanceHookMock,
+  SetToken,
+} from '@setprotocol/set-protocol-v2/dist/utils/contracts';
+
+import SlippageIssuanceModuleWrapper from '@src/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper';
+import { expect } from '../../utils/chai';
+
+const provider = new ethers.providers.JsonRpcProvider();
+const blockchain = new Blockchain(provider);
+
+describe('SlippageIssuanceModuleWrapper', () => {
+  let owner: Address;
+  let manager: Address;
+  let feeRecipient: Address;
+  let randomAddress: Address;
+  let recipient: Address;
+
+  let slippageIssuanceModuleWrapper: SlippageIssuanceModuleWrapper;
+  let slippageIssuanceModule: SlippageIssuanceModule;
+  let debtModule: DebtModuleMock;
+  let externalPositionModule: ModuleIssuanceHookMock;
+
+  let maxFee: BigNumber;
+  let issueFee: BigNumber;
+  let redeemFee: BigNumber;
+
+  let deployer: DeployHelper;
+  let setup: SystemFixture;
+
+  beforeAll(async() => {
+    [
+      owner,
+      manager,
+      feeRecipient,
+      randomAddress,
+      recipient,
+    ] = await provider.listAccounts();
+
+    deployer = new DeployHelper(provider.getSigner(owner));
+    setup = new SystemFixture(provider, owner);
+
+    maxFee = ether(0.02);
+    issueFee = ether(0.005);
+    redeemFee = ether(0.005);
+  });
+
+  beforeEach(async () => {
+    await blockchain.saveSnapshotAsync();
+
+    await setup.initialize();
+
+    slippageIssuanceModule = await deployer.modules.deploySlippageIssuanceModule(setup.controller.address);
+    debtModule = await deployer.mocks.deployDebtModuleMock(setup.controller.address, slippageIssuanceModule.address);
+    externalPositionModule = await deployer.mocks.deployModuleIssuanceHookMock();
+
+    await setup.controller.addModule(slippageIssuanceModule.address);
+    await setup.controller.addModule(debtModule.address);
+    await setup.controller.addModule(externalPositionModule.address);
+
+    slippageIssuanceModuleWrapper = new SlippageIssuanceModuleWrapper(provider, slippageIssuanceModule.address);
+  });
+
+  afterEach(async () => {
+    await blockchain.revertAsync();
+  });
+
+  describe('#initialize', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectCaller: Address;
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address],
+        [ether(1)],
+        [slippageIssuanceModule.address]
+      );
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(0.02);
+      subjectManagerIssueFee = ether(0.005);
+      subjectManagerRedeemFee = ether(0.004);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = randomAddress;
+      subjectCaller = owner;
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<any> {
+      slippageIssuanceModule = slippageIssuanceModule.connect(provider.getSigner(subjectCaller));
+      return slippageIssuanceModuleWrapper.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+        subjectCaller,
+        subjectTransactionOptions,
+      );
+    }
+
+    it('should enable the module on the SetToken', async () => {
+      await subject();
+      const isModuleEnabled = await setToken.isInitializedModule(slippageIssuanceModule.address);
+      expect(isModuleEnabled).to.eq(true);
+    });
+
+    it('should properly set the manager issuance hooks', async () => {
+      await subject();
+      const issuanceSettings = await slippageIssuanceModule.issuanceSettings(subjectSetTokenAddress);
+      const managerIssuanceHook = issuanceSettings.managerIssuanceHook;
+      expect(managerIssuanceHook).to.eq(subjectManagerIssuanceHook);
+    });
+
+    describe('when the issue fee is greater than the maximum fee', () => {
+      beforeEach(async () => {
+        subjectManagerIssueFee = ether(0.03);
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Issue fee can\'t exceed maximum fee');
+      });
+    });
+
+    describe('when the redeem fee is greater than the maximum fee', () => {
+      beforeEach(async () => {
+        subjectManagerRedeemFee = ether(0.03);
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Redeem fee can\'t exceed maximum fee');
+      });
+    });
+
+    describe('when the caller is not the SetToken manager', () => {
+      beforeEach(async () => {
+        subjectCaller = randomAddress;
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Must be the SetToken manager');
+      });
+    });
+
+    describe('when SetToken is not in pending state', () => {
+      beforeEach(async () => {
+        const newModule = randomAddress;
+        await setup.controller.addModule(newModule);
+
+        const slippageIssuanceModuleNotPendingSetToken = await setup.createSetToken(
+          [setup.weth.address],
+          [ether(1)],
+          [newModule]
+        );
+
+        subjectSetTokenAddress = slippageIssuanceModuleNotPendingSetToken.address;
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Must be pending initialization');
+      });
+    });
+
+    describe('when the SetToken is not enabled on the controller', () => {
+      beforeEach(async () => {
+        const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
+          [setup.weth.address],
+          [ether(1)],
+          [slippageIssuanceModule.address]
+        );
+
+        subjectSetTokenAddress = nonEnabledSetToken.address;
+      });
+
+      it('should revert', async () => {
+        await expect(subject()).to.be.rejectedWith('Must be controller-enabled SetToken');
+      });
+    });
+  });
+
+  describe('#issueWithSlippage', () => {
+    let setToken: SetToken;
+
+    let subjectSetToken: Address;
+    let subjectQuantity: BigNumber;
+    let subjectCheckedComponents: Address[];
+    let subjectMaxTokenAmountsIn: BigNumber[];
+    let subjectManagerIssuanceHook: Address;
+    let subjectTo: Address;
+    let subjectCaller: Address;
+
+    const debtUnits: BigNumber = ether(100);
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address],
+        [ether(1)],
+        [setup.issuanceModule.address, slippageIssuanceModule.address, debtModule.address,
+          externalPositionModule.address],
+        manager,
+        'DebtToken',
+        'DBT'
+      );
+
+      await externalPositionModule.initialize(setToken.address);
+
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectSetToken = setToken.address;
+      subjectQuantity = ether(1);
+      subjectCheckedComponents = [];
+      subjectMaxTokenAmountsIn = [];
+      subjectTo = recipient;
+      subjectCaller = owner;
+
+      await slippageIssuanceModule.connect(provider.getSigner(manager)).initialize(
+        subjectSetToken,
+        maxFee,
+        issueFee,
+        redeemFee,
+        feeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      await debtModule.connect(provider.getSigner(manager)).initialize(setToken.address);
+
+      await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
+      await setup.dai.transfer(debtModule.address, ether(100.5));
+
+      const [, equityFlows ] = await slippageIssuanceModule.getRequiredComponentIssuanceUnits(
+        setToken.address, ether(1));
+      await setup.weth.approve(slippageIssuanceModule.address, equityFlows[0].mul(ether(1.005)));
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return slippageIssuanceModuleWrapper.issueWithSlippage(
+        subjectSetToken,
+        subjectQuantity,
+        subjectCheckedComponents,
+        subjectMaxTokenAmountsIn,
+        subjectTo,
+        subjectCaller
+      );
+    }
+
+    it('should mint SetTokens to the correct addresses', async () => {
+      const existingBalance = await setToken.balanceOf(recipient);
+      expect(existingBalance.toString()).to.be.eq(ZERO.toString());
+
+      await subject();
+
+      const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
+      const managerBalance = await setToken.balanceOf(feeRecipient);
+      const toBalance = await setToken.balanceOf(subjectTo);
+
+      expect(toBalance.toString()).to.be.eq(subjectQuantity.toString());
+      expect(managerBalance.toString()).to.be.eq(feeQuantity.toString());
+    });
+  });
+
+  describe('#redeemWithSlippage', () => {
+    let setToken: SetToken;
+
+    let subjectSetToken: Address;
+    let subjectQuantity: BigNumber;
+    let subjectCheckedComponents: Address[];
+    let subjectMinTokenAmountsOut: BigNumber[];
+    let subjectManagerIssuanceHook: Address;
+    let subjectTo: Address;
+    let subjectCaller: Address;
+
+    const debtUnits: BigNumber = ether(100);
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address],
+        [ether(1)],
+        [setup.issuanceModule.address, slippageIssuanceModule.address, debtModule.address,
+          externalPositionModule.address],
+        manager,
+        'DebtToken',
+        'DBT'
+      );
+
+      await externalPositionModule.initialize(setToken.address);
+
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectSetToken = setToken.address;
+      subjectQuantity = ether(1);
+      subjectCheckedComponents = [];
+      subjectMinTokenAmountsOut = [];
+      subjectTo = recipient;
+      subjectCaller = owner;
+
+      await slippageIssuanceModule.connect(provider.getSigner(manager)).initialize(
+        subjectSetToken,
+        maxFee,
+        issueFee,
+        redeemFee,
+        feeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      await debtModule.connect(provider.getSigner(manager)).initialize(setToken.address);
+
+      await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
+      await setup.dai.transfer(debtModule.address, ether(100.5));
+
+      const [, equityFlows ] = await slippageIssuanceModule.getRequiredComponentRedemptionUnits(
+        setToken.address, ether(1));
+      await setup.weth.approve(slippageIssuanceModule.address, equityFlows[0].mul(ether(1.005)));
+
+      await slippageIssuanceModule.issue(setToken.address, ether(1), owner);
+
+      await setup.dai.approve(slippageIssuanceModule.address, ether(100.5));
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return slippageIssuanceModuleWrapper.redeemWithSlippage(
+        subjectSetToken,
+        subjectQuantity,
+        subjectCheckedComponents,
+        subjectMinTokenAmountsOut,
+        subjectTo,
+        subjectCaller
+      );
+    }
+
+    it('should redeem SetTokens to the correct addresses', async () => {
+      const preManagerBalance = await setToken.balanceOf(feeRecipient);
+      const preCallerBalance = await setToken.balanceOf(subjectCaller);
+
+      await subject();
+
+      const feeQuantity = preciseMulCeil(subjectQuantity, redeemFee);
+      const postManagerBalance = await setToken.balanceOf(feeRecipient);
+      const postCallerBalance = await setToken.balanceOf(subjectCaller);
+
+      expect(postManagerBalance.toString()).to.be.eq(preManagerBalance.add(feeQuantity).toString());
+      expect(postCallerBalance.toString()).to.eq(preCallerBalance.sub(subjectQuantity).toString());
+    });
+  });
+
+  describe('#getRequiredComponentIssuanceUnits', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectIssuanceQuantity: BigNumber;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [slippageIssuanceModule.address]
+      );
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(1);
+      subjectManagerIssueFee = ether(0);
+      subjectManagerRedeemFee = ether(0);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectIssuanceQuantity = ether(2);
+      subjectCaller = manager;
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      await slippageIssuanceModule.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      return slippageIssuanceModuleWrapper.getRequiredComponentIssuanceUnits(
+        subjectSetTokenAddress,
+        subjectIssuanceQuantity,
+        subjectCaller
+      );
+    }
+
+    it('should return the correct required quantity of component tokens for issuing', async () => {
+      const [components, equityFlows, debtFlows] = await subject();
+      const wethFlows = preciseMul(subjectIssuanceQuantity, ether(1));
+      const wbtcFlows = preciseMulCeil(subjectIssuanceQuantity, bitcoin(2));
+
+      const expectedComponents = await setToken.getComponents();
+      const expectedEquityFlows = [wethFlows, wbtcFlows];
+      const expectedDebtFlows = [ZERO, ZERO];
+
+      expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+      expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+      expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+    });
+
+    describe('when there\'s an issuance fee', () => {
+      beforeEach(() => {
+        subjectManagerIssueFee = ether(0.01);
+      });
+
+      it('should return required amount with fee', async () => {
+        const [components, equityFlows, debtFlows] = await subject();
+        const mintQuantity = preciseMul(subjectIssuanceQuantity, ether(1).add(subjectManagerIssueFee));
+        const wethFlows = preciseMul(mintQuantity, ether(1));
+        const wbtcFlows = preciseMulCeil(mintQuantity, bitcoin(2));
+
+        const expectedComponents = await setToken.getComponents();
+        const expectedEquityFlows = [wethFlows, wbtcFlows];
+        const expectedDebtFlows = [ZERO, ZERO];
+
+        expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+        expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+        expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+      });
+    });
+  });
+
+  describe('#getRequiredComponentRedemptionUnits', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectRedemptionQuantity: BigNumber;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [slippageIssuanceModule.address]
+      );
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(1);
+      subjectManagerIssueFee = ether(0);
+      subjectManagerRedeemFee = ether(0);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectRedemptionQuantity = ether(2);
+      subjectCaller = manager;
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      await slippageIssuanceModule.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      return slippageIssuanceModuleWrapper.getRequiredComponentRedemptionUnits(
+        subjectSetTokenAddress,
+        subjectRedemptionQuantity,
+        subjectCaller
+      );
+    }
+
+    it('should return the correct required quantity of component tokens for redeeming', async () => {
+      const [components, equityFlows, debtFlows] = await subject();
+      const wethFlows = preciseMul(subjectRedemptionQuantity, ether(1));
+      const wbtcFlows = preciseMulCeil(subjectRedemptionQuantity, bitcoin(2));
+
+      const expectedComponents = await setToken.getComponents();
+      const expectedEquityFlows = [wethFlows, wbtcFlows];
+      const expectedDebtFlows = [ZERO, ZERO];
+
+      expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+      expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+      expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+    });
+
+    describe('when there\'s a redemption fee', () => {
+      beforeEach(() => {
+        subjectManagerRedeemFee = ether(0.01);
+      });
+
+      it('should return required amount with fee', async () => {
+        const [components, equityFlows, debtFlows] = await subject();
+        const mintQuantity = preciseMul(subjectRedemptionQuantity, ether(1).sub(subjectManagerRedeemFee));
+        const wethFlows = preciseMul(mintQuantity, ether(1));
+        const wbtcFlows = preciseMulCeil(mintQuantity, bitcoin(2));
+
+        const expectedComponents = await setToken.getComponents();
+        const expectedEquityFlows = [wethFlows, wbtcFlows];
+        const expectedDebtFlows = [ZERO, ZERO];
+
+        expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+        expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+        expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+      });
+    });
+  });
+
+  describe('#calculateTotalFees', () => {
+    let setToken: SetToken;
+
+    let subjectSetTokenAddress: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+    let subjectQuantity: BigNumber;
+    let subjectIsIssue: boolean;
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      setToken = await setup.createSetToken(
+        [setup.weth.address, setup.wbtc.address],
+        [ether(1), bitcoin(2)],
+        [slippageIssuanceModule.address]
+      );
+
+      subjectSetTokenAddress = setToken.address;
+      subjectMaxManagerFee = ether(1);
+      subjectManagerIssueFee = ether(0);
+      subjectManagerRedeemFee = ether(0);
+      subjectFeeRecipient = owner;
+      subjectManagerIssuanceHook = ADDRESS_ZERO;
+      subjectQuantity = ether(2);
+      subjectCaller = manager;
+    });
+
+    async function subject(): Promise<
+      [BigNumber, BigNumber, BigNumber] & {
+        totalQuantity: BigNumber;
+        managerFee: BigNumber;
+        protocolFee: BigNumber;
+      }
+    > {
+      await slippageIssuanceModule.initialize(
+        subjectSetTokenAddress,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook,
+      );
+
+      return slippageIssuanceModuleWrapper.calculateTotalFees(
+        subjectSetTokenAddress,
+        subjectQuantity,
+        subjectIsIssue,
+        subjectCaller
+      );
+    }
+    describe('when calculateTotalFees is used for issuance with no issue fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = true;
+      });
+
+      it('should return no issue fee value', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = subjectQuantity;
+        const expectedManagerFeeAmount = ether(0);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+
+    describe('when there\'s an issue fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = true;
+        subjectManagerIssueFee = ether(0.01);
+      });
+
+      it('should return required amount with issue fee', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = preciseMul(subjectQuantity, ether(1).add(subjectManagerIssueFee));
+        const expectedManagerFeeAmount = preciseMul(subjectQuantity, subjectManagerIssueFee);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+
+    describe('when calculateTotalFees is used for redemption with no redeem fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = false;
+      });
+
+      it('should return no redeem fee value', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = subjectQuantity;
+        const expectedManagerFeeAmount = ether(0);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+
+    describe('when there\'s a redeem fee', () => {
+      beforeEach(() => {
+        subjectIsIssue = false;
+        subjectManagerRedeemFee = ether(0.01);
+      });
+
+      it('should return required amount with redeem fee', async () => {
+        const [issuedSetsAmount, managerFeeAmount, protocolFeeAmount] = await subject();
+        const expectedIssuedSetsAmount = preciseMul(subjectQuantity, ether(1).sub(subjectManagerRedeemFee));
+        const expectedManagerFeeAmount = preciseMul(subjectQuantity, subjectManagerRedeemFee);
+        const expectedProtocolFeeAmount = ether(0);
+
+        expect(JSON.stringify(issuedSetsAmount)).to.eq(JSON.stringify(expectedIssuedSetsAmount));
+        expect(JSON.stringify(managerFeeAmount)).to.eq(JSON.stringify(expectedManagerFeeAmount));
+        expect(JSON.stringify(protocolFeeAmount)).to.eq(JSON.stringify(expectedProtocolFeeAmount));
+      });
+    });
+  });
+});


### PR DESCRIPTION
New Wrapper class within set.js to be able to abstract away the SlippageIssuanceModule interface.

Added unit tests for the new functions `issueWithSlippage` and `redeemWithSlippage`