### PR TITLE
Add the SlippageIssuanceAPI to the Set.JS Index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -30,6 +30,7 @@ import {
   PriceOracleAPI,
   DebtIssuanceAPI,
   DebtIssuanceV2API,
+  SlippageIssuanceAPI,
 } from './api/index';
 
 const ethersProviders = require('ethers').providers;
@@ -105,6 +106,13 @@ class Set {
   public debtIssuanceV2: DebtIssuanceV2API;
 
   /**
+   * An instance of the SlippageIssuanceAPI class. Contains interfaces for interacting
+   * with the SlippageIssuanceAPI contract to to trade into/from tokens during the issuance and
+   * redemption step. Initially used for Perpetual Leverage Tokens.
+   */
+  public slippageIssuance: SlippageIssuanceAPI;
+
+  /**
    * An instance of the BlockchainAPI class. Contains interfaces for
    * interacting with the blockchain
    */
@@ -136,6 +144,7 @@ class Set {
     this.priceOracle = new PriceOracleAPI(ethersProvider, config.masterOracleAddress);
     this.debtIssuance = new DebtIssuanceAPI(ethersProvider, config.debtIssuanceModuleAddress);
     this.debtIssuanceV2 = new DebtIssuanceV2API(ethersProvider, config.debtIssuanceModuleV2Address);
+    this.slippageIssuance = new SlippageIssuanceAPI(ethersProvider, config.slippageIssuanceModuleAddress);
     this.blockchain = new BlockchainAPI(ethersProvider, assertions);
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ import NavIssuanceAPI from './NavIssuanceAPI';
 import PriceOracleAPI from './PriceOracleAPI';
 import DebtIssuanceAPI from './DebtIssuanceAPI';
 import DebtIssuanceV2API from './DebtIssuanceV2API';
+import SlippageIssuanceAPI from './SlippageIssuanceAPI';
 import {
   TradeQuoter,
   CoinGeckoDataService,
@@ -27,6 +28,7 @@ export {
   PriceOracleAPI,
   DebtIssuanceAPI,
   DebtIssuanceV2API,
+  SlippageIssuanceAPI,
   TradeQuoter,
   CoinGeckoDataService,
   GasOracleService

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -20,6 +20,7 @@ export interface SetJSConfig {
   debtIssuanceModuleAddress: Address;
   zeroExApiKey?: string;
   debtIssuanceModuleV2Address: Address;
+  slippageIssuanceModuleAddress: Address;
 }
 
 export type SetDetails = {


### PR DESCRIPTION
Previously we checked in the API and Wrapper class. Now we add it to set.ts and index.ts to be properly consumed by downstream clients (missed this in the previous bump)