### PR TITLE
Patch SIM issuance/redemption units getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@0xproject/types": "^1.1.4",
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
-        "@setprotocol/set-protocol-v2": "^0.1.5",
+        "@setprotocol/set-protocol-v2": "^0.1.8",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.ts
+++ b/src/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.ts
@@ -192,7 +192,7 @@ export default class SlippageIssuanceModuleV2Wrapper {
       callerAddress
     );
 
-    return await slippageIssuanceModuleInstance.getRequiredComponentIssuanceUnits(
+    return await slippageIssuanceModuleInstance.callStatic.getRequiredComponentIssuanceUnitsOffChain(
       setTokenAddress,
       quantity,
     );
@@ -222,7 +222,7 @@ export default class SlippageIssuanceModuleV2Wrapper {
       callerAddress
     );
 
-    return await slippageIssuanceModuleInstance.getRequiredComponentRedemptionUnits(
+    return await slippageIssuanceModuleInstance.callStatic.getRequiredComponentRedemptionUnitsOffChain(
       setTokenAddress,
       quantity,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,10 +1016,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@setprotocol/set-protocol-v2@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.5.tgz#c6c559f749866b5a95b5871bb1447fa4d8f7a9c2"
-  integrity sha512-UcbIxfFAARcCi9Yt4xde1Gc7xKrhMpCSGMgzpxEVBJFZPEYiYny1tv4W9lFopxQ9o81ZC7/SO6oZvYdMEuUZzQ==
+"@setprotocol/set-protocol-v2@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.8.tgz#d936be0807edd7fdfd6310b124fd6f28f63d950e"
+  integrity sha512-4Tu+UGfJjpHwVZukE9WnA1gke7DR7ba48LY/A66Z87yQDs+I/VfRE9lG5yCL7g8SpOpvQ2DoL9lq3NunsuITog==
   dependencies:
     "@uniswap/v3-sdk" "^3.5.1"
     ethers "^5.5.2"


### PR DESCRIPTION
This PR is necessary to resolve set-ui reverts when fetching required issuance units for Perp Leverage tokens using the SIM.  

PR:
+ Updates set-protocol-v2 to v.0.1.8 which includes fixes to the SIM interface from [set-protocol-v2 PR 182][1]
+ Updates SIM wrapper logic to `callStatic` new non-view units getters



[1]: https://github.com/SetProtocol/set-protocol-v2/pull/182