### PR TITLE
Convert wei to gwei in Optimism gas fetcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.6",
+    "version": "0.4.7",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/api/utils/gasOracle.ts
+++ b/src/api/utils/gasOracle.ts
@@ -79,7 +79,7 @@ export class GasOracleService {
   private async getOptimismGasPrice(): Promise<number> {
     const url = 'https://api-optimistic.etherscan.io/api?module=proxy&action=eth_gasPrice';
     const data = (await axios.get(url)).data;
-    const price = Number(data.result);
+    const price = Number(data.result) / 1000000000; // wei to gwei
 
     return price;
   }


### PR DESCRIPTION
Prices are too high when viewed from a library client (e.g. set-ui when manually fetching for price instead of relying on native call).