### PR TITLE
Add PerpV2LeverageModule factory and Wrapper/tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@0xproject/types": "^1.1.4",
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
-        "@setprotocol/set-protocol-v2": "^0.1.8",
+        "@setprotocol/set-protocol-v2": "^0.1.9",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/src/wrappers/set-protocol-v2/ContractWrapper.ts
+++ b/src/wrappers/set-protocol-v2/ContractWrapper.ts
@@ -32,6 +32,7 @@ import {
   StreamingFeeModule,
   TradeModule,
   NavIssuanceModule,
+  PerpV2LeverageModule,
   PriceOracle,
 } from '@setprotocol/set-protocol-v2/typechain';
 import { BasicIssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/BasicIssuanceModule__factory';
@@ -46,6 +47,7 @@ import { SetTokenCreator__factory } from '@setprotocol/set-protocol-v2/dist/type
 import { StreamingFeeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/StreamingFeeModule__factory';
 import { TradeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/TradeModule__factory';
 import { NavIssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/NavIssuanceModule__factory';
+import { PerpV2LeverageModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/PerpV2LeverageModule__factory';
 import { PriceOracle__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/PriceOracle__factory';
 
 /**
@@ -419,6 +421,33 @@ export default class ContractWrapper {
 
       this.cache[cacheKey] = slippageIssuanceModuleContract;
       return slippageIssuanceModuleContract;
+    }
+  }
+
+  /**
+   * Load PerpV2LeverageModule contract
+   *
+   * @param  perpV2LeverageModuleAddress     Address of the Perp V2 Leverage module
+   * @param  callerAddress                   Address of caller, uses first one on node if none provided.
+   * @return                                 PerpV2LeverageModule contract instance
+   */
+   public async loadPerpV2LeverageModuleAsync(
+    perpV2LeverageModuleAddress: Address,
+    callerAddress?: Address,
+  ): Promise<PerpV2LeverageModule> {
+    const signer = (this.provider as JsonRpcProvider).getSigner(callerAddress);
+    const cacheKey = `PerpV2LeverageModule_${perpV2LeverageModuleAddress}_${await signer.getAddress()}`;
+
+    if (cacheKey in this.cache) {
+      return this.cache[cacheKey] as PerpV2LeverageModule;
+    } else {
+      const perpV2LeverageModuleContract = PerpV2LeverageModule__factory.connect(
+        perpV2LeverageModuleAddress,
+        signer
+      );
+
+      this.cache[cacheKey] = perpV2LeverageModuleContract;
+      return perpV2LeverageModuleContract;
     }
   }
 }

--- a/src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper.ts
+++ b/src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper.ts
@@ -1,0 +1,171 @@
+/*
+  Copyright 2022 Set Labs Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { BigNumber, ContractTransaction } from 'ethers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { Provider } from '@ethersproject/providers';
+import { generateTxOpts } from '../../utils/transactions';
+
+import ContractWrapper from './ContractWrapper';
+
+/**
+ * @title  PerpV2LeverageModuleWrapper
+ * @author Set Protocol
+ *
+ * The PerpV2LeverageModuleWrapper forwards functionality from the PerpV2LeverageModule contract.
+ *
+ */
+export default class PerpV2LeverageModuleWrapper {
+  private provider: Provider;
+  private contracts: ContractWrapper;
+
+  private perpV2LeverageModuleAddress: Address;
+
+  public constructor(provider: Provider, perpV2LeverageModuleAddress: Address) {
+    this.provider = provider;
+    this.contracts = new ContractWrapper(this.provider);
+    this.perpV2LeverageModuleAddress = perpV2LeverageModuleAddress;
+  }
+
+  /**
+   * Initializes this module to the SetToken. Only callable by the SetToken's manager.
+   *
+   * @param setTokenAddress             Address of the SetToken to initialize
+   * @param callerAddress               Address of caller (optional)
+   * @param txOpts                      Overrides for transaction (optional)
+   */
+  public async initialize(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const perpV2LeverageModuleInstance = await this.contracts.loadPerpV2LeverageModuleAsync(
+      this.perpV2LeverageModuleAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleInstance.initialize(
+      setTokenAddress,
+      txOptions,
+    );
+  }
+
+  /**
+   * Gets the address of the collateral token
+   *
+   * @param  callerAddress Address of the method caller
+   * @return               The address of the ERC20 collateral token
+   */
+  public async collateralToken(
+    callerAddress: Address = undefined,
+  ): Promise<Address> {
+    const perpV2LeverageModuleInstance = await this.contracts.loadPerpV2LeverageModuleAsync(
+      this.perpV2LeverageModuleAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleInstance.collateralToken();
+  }
+
+  /**
+   * Gets decimals of the collateral token
+   *
+   * @param  callerAddress Address of the method caller
+   * @return               The decimals of the ERC20 collateral token
+   */
+  public async collateralDecimals(
+    callerAddress: Address = undefined,
+  ): Promise<Number> {
+    const perpV2LeverageModuleInstance = await this.contracts.loadPerpV2LeverageModuleAsync(
+      this.perpV2LeverageModuleAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleInstance.collateralDecimals();
+  }
+
+  /**
+   * Returns a PositionUnitNotionalInfo array representing all positions open for the SetToken.
+   *
+   * @param _setToken         Instance of SetToken
+   *
+   * @return address[]        baseToken: addresses
+   * @return BigNumber[]      baseBalance: baseToken balances as notional quantity (10**18)
+   * @return BigNumber[]      quoteBalance: USDC quote asset balances as notional quantity (10**18)
+   */
+  public async getPositionNotionalInfo(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    const perpV2LeverageModuleInstance = await this.contracts.loadPerpV2LeverageModuleAsync(
+      this.perpV2LeverageModuleAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleInstance.getPositionNotionalInfo(
+      setTokenAddress,
+    );
+  }
+
+  /**
+   * Returns a PositionUnitInfo array representing all positions open for the SetToken.
+   *
+   * @param _setToken         Instance of SetToken
+   *
+   * @return address[]        baseToken: addresses
+   * @return BigNumber[]      baseUnit: baseToken balances as position unit (10**18)
+   * @return BigNumber[]      quoteUnit: USDC quote asset balances as position unit (10**18)
+   */
+  public async getPositionUnitInfo(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+  ): Promise<(Address|BigNumber)[][]> {
+    const perpV2LeverageModuleInstance = await this.contracts.loadPerpV2LeverageModuleAsync(
+      this.perpV2LeverageModuleAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleInstance.getPositionUnitInfo(
+      setTokenAddress,
+    );
+  }
+
+  /**
+   * Gets Perp account info for SetToken. Returns an AccountInfo struct containing account wide
+   * (rather than position specific) balance info
+   *
+   * @param  _setToken            Instance of the SetToken
+   *
+   * @return BigNumber            collateral balance (10**18, regardless of underlying collateral decimals)
+   * @return BigNumber            owed realized Pnl` (10**18)
+   * @return BigNumber            pending funding payments (10**18)
+   * @return BigNumber            net quote balance (10**18)
+   */
+  public async getAccountInfo(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+  ): Promise<BigNumber[]> {
+    const perpV2LeverageModuleInstance = await this.contracts.loadPerpV2LeverageModuleAsync(
+      this.perpV2LeverageModuleAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleInstance.getAccountInfo(
+      setTokenAddress,
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,10 +1016,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@setprotocol/set-protocol-v2@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.8.tgz#d936be0807edd7fdfd6310b124fd6f28f63d950e"
-  integrity sha512-4Tu+UGfJjpHwVZukE9WnA1gke7DR7ba48LY/A66Z87yQDs+I/VfRE9lG5yCL7g8SpOpvQ2DoL9lq3NunsuITog==
+"@setprotocol/set-protocol-v2@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.9.tgz#1b0eef8667d01405f0b259bc5129986e5db7b53b"
+  integrity sha512-sPbCD6ngw4yIosXyOT+ytFZbFeMyHNOgDA6hdhrXkllsSKoJ2thc9Y6SqzF5kCPkK+bKmVhNF+cMTDMX0lemZg==
   dependencies:
     "@uniswap/v3-sdk" "^3.5.1"
     ethers "^5.5.2"


### PR DESCRIPTION
* Bump the set-protocol-v2 library in package.json
* Add the PerpV2LeverageModule factory into the Contract wrapper construct
* Create a PerpV2LeverageModuleWrapper class

Follow up PR will update the set.js config and add the API class/tests

Note - To deduplicate contract testing code I opted to rely on upcoming API tests to create expectations that contract instances are correct called via the Wrapper class. Including smart contract level tests within set.js seems to create redundant guarantees when the set-protocol-v2 repo should be the source of truth for implementation/tests.