### PR TITLE
Create new PerpV2LeverageViewerAPI for PerpModule Viewer contract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/set.js/.npmrc
       - run:
           name: Inject Truffle
-          command: yarn global add truffle
+          command: yarn global add truffle --ignore-engines
       - run:
           name: Fetch Dependencies
           command: yarn install --network-concurrency 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@0xproject/types": "^1.1.4",
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
-        "@setprotocol/set-protocol-v2": "^0.1.9",
+        "@setprotocol/set-protocol-v2": "^0.1.10",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -31,8 +31,9 @@ import {
   DebtIssuanceAPI,
   DebtIssuanceV2API,
   SlippageIssuanceAPI,
+  PerpV2LeverageAPI,
+  PerpV2LeverageViewerAPI,
 } from './api/index';
-import PerpV2LeverageAPI from './api/PerpV2LeverageAPI';
 
 const ethersProviders = require('ethers').providers;
 
@@ -116,9 +117,16 @@ class Set {
   /**
    * An instance of the PerpV2LeverageAPI class. Contains getters for fetching
    * positional (per Set) and notional (across all Sets) units for collateral, vAssets, and debt.
-   * Initially used for Perpetual Leverage Tokens.
+   * Getters return low level data; for more abstracted data use the PerpV2LeverageViewerAPI.
    */
   public perpV2Leverage: PerpV2LeverageAPI;
+
+  /**
+   * An instance of the PerpV2LeverageViewerAPI class. Contains getters for fetching total
+   * collateral balance (which includes PnL and funding), virtual component leverage ratios,
+   * and maximum issuance quantity computed from token supply.
+   */
+  public perpV2LeverageViewer: PerpV2LeverageViewerAPI;
 
   /**
    * An instance of the BlockchainAPI class. Contains interfaces for
@@ -154,6 +162,7 @@ class Set {
     this.debtIssuanceV2 = new DebtIssuanceV2API(ethersProvider, config.debtIssuanceModuleV2Address);
     this.slippageIssuance = new SlippageIssuanceAPI(ethersProvider, config.slippageIssuanceModuleAddress);
     this.perpV2Leverage = new PerpV2LeverageAPI(ethersProvider, config.perpV2LeverageModuleAddress);
+    this.perpV2LeverageViewer = new PerpV2LeverageViewerAPI(ethersProvider, config.perpV2LeverageModuleViewerAddress);
     this.blockchain = new BlockchainAPI(ethersProvider, assertions);
   }
 }

--- a/src/api/PerpV2LeverageAPI.ts
+++ b/src/api/PerpV2LeverageAPI.ts
@@ -81,18 +81,6 @@ export default class PerpV2LeverageAPI {
   }
 
   /**
-   * Gets decimals of the collateral token
-   *
-   * @param  callerAddress            The address of user transferring from (optional)
-   * @return                          The decimals of the ERC20 collateral token
-   */
-  public async getCollateralDecimalsAsync(
-    callerAddress: Address = undefined,
-  ): Promise<Number> {
-    return await this.perpV2LeverageModuleWrapper.collateralDecimals(callerAddress);
-  }
-
-  /**
    * Returns a tuple of arrays representing all positions open for the SetToken.
    *
    * @param _setToken                 Instance of SetToken

--- a/src/api/PerpV2LeverageViewerAPI.ts
+++ b/src/api/PerpV2LeverageViewerAPI.ts
@@ -1,0 +1,157 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { ContractTransaction } from 'ethers';
+import { Provider } from '@ethersproject/providers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { BigNumber } from 'ethers/lib/ethers';
+import { VAssetDisplayInfo } from '../types';
+
+import PerpV2LeverageModuleViewerWrapper from '../wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper';
+import Assertions from '../assertions';
+
+/**
+ * @title  PerpV2LeverageViewerAPI
+ * @author Set Protocol
+ *
+ * The PerpV2LeverageViewerAPI exposes issue and redeem functionality for Sets that contain poitions that accrue
+ * interest per block. The getter function syncs the position balance to the current block, so subsequent blocks
+ * will cause the position value to be slightly out of sync (a buffer is needed). This API is primarily used for Sets
+ * that rely on the ALM contracts to manage debt. The manager can define arbitrary issuance logic
+ * in the manager hook, as well as specify issue and redeem fees.
+ *
+ */
+export default class PerpV2LeverageViewerAPI {
+  private perpV2LeverageModuleViewerWrapper: PerpV2LeverageModuleViewerWrapper;
+  private assert: Assertions;
+
+  public constructor(provider: Provider, perpV2LeverageModuleViewerAddress: Address, assertions?: Assertions) {
+    this.perpV2LeverageModuleViewerWrapper = new PerpV2LeverageModuleViewerWrapper(
+      provider,
+      perpV2LeverageModuleViewerAddress
+    );
+    this.assert = assertions || new Assertions();
+  }
+
+  /**
+   * Initializes the PerpV2LeverageModuleViewer to the SetToken. Only callable by the SetToken's manager.
+   *
+   * @param setTokenAddress             Address of the SetToken to initialize
+   * @param callerAddress               The address of user transferring from (optional)
+   * @param txOpts                      Overrides for transaction (optional)
+   *
+   * @return                            Transaction hash of the initialize transaction
+   */
+  public async initializeAsync(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+
+    return await this.perpV2LeverageModuleViewerWrapper.initialize(
+      setTokenAddress,
+      callerAddress,
+      txOpts,
+    );
+  }
+
+  /**
+   * Gets the address of the collateral token
+   *
+   * @param  callerAddress            The address of user transferring from (optional)
+   * @return                          The address of the ERC20 collateral token
+   */
+   public async getCollateralTokenAsync(
+    callerAddress: Address = undefined,
+  ): Promise<Address> {
+    return await this.perpV2LeverageModuleViewerWrapper.collateralToken(callerAddress);
+  }
+
+  /**
+   * Returns the maximum amount of Sets that can be issued. Because upon issuance we lever up the Set
+   * before depositing collateral there is a ceiling on the amount of Sets that can be issued before the max
+   * leverage ratio is met. In order to accurately predict this amount the user must pass in an expected
+   * slippage amount, this amount should be calculated relative to Index price(s) of vAssets held by the Set,
+   * not the mid-market prices. The formulas used here are based on the "conservative" definition of free
+   * collateral as defined in PerpV2's docs.
+   *
+   * @param setTokenAddress           Instance of SetToken
+   * @param slippage                  Expected slippage from entering position in precise units (1% = 10^16)
+   * @param callerAddress             Address of the method caller
+   *
+   * @return                          Maximum amount of Sets that can be issued
+   */
+  public async getMaximumSetTokenIssueAmountAsync(
+    setTokenAddress: Address,
+    slippage: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<BigNumber> {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+
+    return await this.perpV2LeverageModuleViewerWrapper.getMaximumSetTokenIssueAmount(
+      setTokenAddress,
+      slippage,
+      callerAddress,
+    );
+  }
+
+  /**
+   * Returns the position unit for total collateral value as defined by Perpetual Protocol.
+   *
+   * @param setTokenAddress           Instance of SetToken
+   * @param callerAddress             Address of the method caller
+   *
+   * @return                          Collateral token address
+   * @return                          Total collateral value position unit
+   */
+  public async getTotalCollateralUnitAsync(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+  ): Promise<[Address, BigNumber]> {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+
+    return await this.perpV2LeverageModuleViewerWrapper.getTotalCollateralUnit(
+      setTokenAddress,
+      callerAddress,
+    );
+  }
+
+  /**
+   * Returns relevant data for displaying current positions. Identifying info for each position plus current
+   * size, index price, and leverage of each vAsset with an open position is returned. The sum quantity of vUSDC
+   * is returned along with identifying info in last index of array.
+   *
+   * @param setTokenAddress           Instance of the SetToken
+   * @param callerAddress             Address of the method caller
+   *
+   * @return                          Array of info concerning size and leverage of current vAsset positions
+   */
+  public async getVirtualAssetsDisplayInfoAsync(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+  ): Promise<VAssetDisplayInfo[]> {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+
+    return await this.perpV2LeverageModuleViewerWrapper.getVirtualAssetsDisplayInfo(
+      setTokenAddress,
+      callerAddress,
+    );
+  }
+}

--- a/src/api/PerpV2LeverageViewerAPI.ts
+++ b/src/api/PerpV2LeverageViewerAPI.ts
@@ -16,10 +16,8 @@
 
 'use strict';
 
-import { ContractTransaction } from 'ethers';
 import { Provider } from '@ethersproject/providers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
-import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
 import { BigNumber } from 'ethers/lib/ethers';
 import { VAssetDisplayInfo } from '../types';
 
@@ -47,29 +45,6 @@ export default class PerpV2LeverageViewerAPI {
       perpV2LeverageModuleViewerAddress
     );
     this.assert = assertions || new Assertions();
-  }
-
-  /**
-   * Initializes the PerpV2LeverageModuleViewer to the SetToken. Only callable by the SetToken's manager.
-   *
-   * @param setTokenAddress             Address of the SetToken to initialize
-   * @param callerAddress               The address of user transferring from (optional)
-   * @param txOpts                      Overrides for transaction (optional)
-   *
-   * @return                            Transaction hash of the initialize transaction
-   */
-  public async initializeAsync(
-    setTokenAddress: Address,
-    callerAddress: Address = undefined,
-    txOpts: TransactionOverrides = {}
-  ): Promise<ContractTransaction> {
-    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
-
-    return await this.perpV2LeverageModuleViewerWrapper.initialize(
-      setTokenAddress,
-      callerAddress,
-      txOpts,
-    );
   }
 
   /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,6 +11,7 @@ import DebtIssuanceAPI from './DebtIssuanceAPI';
 import DebtIssuanceV2API from './DebtIssuanceV2API';
 import SlippageIssuanceAPI from './SlippageIssuanceAPI';
 import PerpV2LeverageAPI from './PerpV2LeverageAPI';
+import PerpV2LeverageViewerAPI from './PerpV2LeverageViewerAPI';
 import {
   TradeQuoter,
   CoinGeckoDataService,
@@ -31,6 +32,7 @@ export {
   DebtIssuanceV2API,
   SlippageIssuanceAPI,
   PerpV2LeverageAPI,
+  PerpV2LeverageViewerAPI,
   TradeQuoter,
   CoinGeckoDataService,
   GasOracleService

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,6 +22,7 @@ export interface SetJSConfig {
   debtIssuanceModuleV2Address: Address;
   slippageIssuanceModuleAddress: Address;
   perpV2LeverageModuleAddress: Address;
+  perpV2LeverageModuleViewerAddress: Address;
 }
 
 export type SetDetails = {
@@ -89,3 +90,12 @@ export enum ModuleState {
   'PENDING',
   'INITIALIZED',
 }
+
+// For PerpV2LeverageModuleViewerWrapper
+export type VAssetDisplayInfo = {
+  symbol: string;
+  address: Address;
+  positionUnit: BigNumber;
+  indexPrice: BigNumber;
+  currentLeverageRatio: BigNumber;
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -94,8 +94,8 @@ export enum ModuleState {
 // For PerpV2LeverageModuleViewerWrapper
 export type VAssetDisplayInfo = {
   symbol: string;
-  address: Address;
-  positionUnit: BigNumber;
-  indexPrice: BigNumber;
-  currentLeverageRatio: BigNumber;
+  vAssetAddress: Address;
+  positionUnit: BigNumber; // 10^18 decimals
+  indexPrice: BigNumber; // 10^18 decimals
+  currentLeverageRatio: BigNumber; // 10^18 decimals
 };

--- a/src/wrappers/set-protocol-v2/ContractWrapper.ts
+++ b/src/wrappers/set-protocol-v2/ContractWrapper.ts
@@ -33,6 +33,7 @@ import {
   TradeModule,
   NavIssuanceModule,
   PerpV2LeverageModule,
+  PerpV2LeverageModuleViewer,
   PriceOracle,
 } from '@setprotocol/set-protocol-v2/typechain';
 import { BasicIssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/BasicIssuanceModule__factory';
@@ -48,6 +49,7 @@ import { StreamingFeeModule__factory } from '@setprotocol/set-protocol-v2/dist/t
 import { TradeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/TradeModule__factory';
 import { NavIssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/NavIssuanceModule__factory';
 import { PerpV2LeverageModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/PerpV2LeverageModule__factory';
+import { PerpV2LeverageModuleViewer__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/PerpV2LeverageModuleViewer__factory';
 import { PriceOracle__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/PriceOracle__factory';
 
 /**
@@ -448,6 +450,33 @@ export default class ContractWrapper {
 
       this.cache[cacheKey] = perpV2LeverageModuleContract;
       return perpV2LeverageModuleContract;
+    }
+  }
+
+  /**
+   * Load PerpV2LeverageModuleViewer contract
+   *
+   * @param  perpV2LeverageModuleViewerAddress     Address of the Perp V2 Leverage module viewer
+   * @param  callerAddress                         Address of caller, uses first one on node if none provided.
+   * @return                                       PerpV2LeverageModuleViewer contract instance
+   */
+   public async loadPerpV2LeverageModuleViewerAsync(
+    perpV2LeverageModuleViewerAddress: Address,
+    callerAddress?: Address,
+  ): Promise<PerpV2LeverageModuleViewer> {
+    const signer = (this.provider as JsonRpcProvider).getSigner(callerAddress);
+    const cacheKey = `PerpV2LeverageModuleViewer_${perpV2LeverageModuleViewerAddress}_${await signer.getAddress()}`;
+
+    if (cacheKey in this.cache) {
+      return this.cache[cacheKey] as PerpV2LeverageModuleViewer;
+    } else {
+      const perpV2LeverageModuleViewerContract = PerpV2LeverageModuleViewer__factory.connect(
+        perpV2LeverageModuleViewerAddress,
+        signer
+      );
+
+      this.cache[cacheKey] = perpV2LeverageModuleViewerContract;
+      return perpV2LeverageModuleViewerContract;
     }
   }
 }

--- a/src/wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper.ts
+++ b/src/wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper.ts
@@ -1,0 +1,161 @@
+/*
+  Copyright 2022 Set Labs Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { BigNumber, ContractTransaction } from 'ethers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { Provider } from '@ethersproject/providers';
+import { generateTxOpts } from '../../utils/transactions';
+import { VAssetDisplayInfo } from '../../types';
+
+import ContractWrapper from './ContractWrapper';
+
+/**
+ * @title  PerpV2LeverageModuleViewerWrapper
+ * @author Set Protocol
+ *
+ * The PerpV2LeverageModuleViewerWrapper forwards functionality from the PerpV2LeverageModule contract.
+ *
+ */
+export default class PerpV2LeverageModuleViewerWrapper {
+  private provider: Provider;
+  private contracts: ContractWrapper;
+
+  private perpV2LeverageModuleViewerAddress: Address;
+
+  public constructor(provider: Provider, perpV2LeverageModuleViewerAddress: Address) {
+    this.provider = provider;
+    this.contracts = new ContractWrapper(this.provider);
+    this.perpV2LeverageModuleViewerAddress = perpV2LeverageModuleViewerAddress;
+  }
+
+  /**
+   * Initializes this module to the SetToken. Only callable by the SetToken's manager.
+   *
+   * @param setTokenAddress             Address of the SetToken to initialize
+   * @param callerAddress               Address of caller (optional)
+   * @param txOpts                      Overrides for transaction (optional)
+   */
+  public async initialize(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const perpV2LeverageModuleViewerInstance = await this.contracts.loadPerpV2LeverageModuleViewerAsync(
+      this.perpV2LeverageModuleViewerAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleViewerInstance.initialize(
+      setTokenAddress,
+      txOptions,
+    );
+  }
+
+  /**
+   * Gets the address of the collateral token
+   *
+   * @param  callerAddress            Address of the method caller
+   * @return                          The address of the ERC20 collateral token
+   */
+  public async collateralToken(
+    callerAddress: Address = undefined,
+  ): Promise<Address> {
+    const perpV2LeverageModuleViewerInstance = await this.contracts.loadPerpV2LeverageModuleViewerAsync(
+      this.perpV2LeverageModuleViewerAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleViewerInstance.collateralToken();
+  }
+
+  /**
+   * Returns the maximum amount of Sets that can be issued. Because upon issuance we lever up the Set
+   * before depositing collateral there is a ceiling on the amount of Sets that can be issued before the max
+   * leverage ratio is met. In order to accurately predict this amount the user must pass in an expected
+   * slippage amount, this amount should be calculated relative to Index price(s) of vAssets held by the Set,
+   * not the mid-market prices. The formulas used here are based on the "conservative" definition of free
+   * collateral as defined in PerpV2's docs.
+   *
+   * @param setTokenAddress           Instance of SetToken
+   * @param slippage                  Expected slippage from entering position in precise units (1% = 10^16)
+   * @param callerAddress             Address of the method caller
+   *
+   * @return                          Maximum amount of Sets that can be issued
+   */
+  public async getMaximumSetTokenIssueAmount(
+    setTokenAddress: Address,
+    slippage: BigNumber,
+    callerAddress: Address = undefined,
+  ): Promise<BigNumber> {
+    const perpV2LeverageModuleViewerInstance = await this.contracts.loadPerpV2LeverageModuleViewerAsync(
+      this.perpV2LeverageModuleViewerAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleViewerInstance.getMaximumSetTokenIssueAmount(
+      setTokenAddress,
+      slippage,
+    );
+  }
+
+  /**
+   * Returns the position unit for total collateral value as defined by Perpetual Protocol.
+   *
+   * @param setTokenAddress           Instance of SetToken
+   * @param callerAddress             Address of the method caller
+   *
+   * @return                          Collateral token address
+   * @return                          Total collateral value position unit
+   */
+  public async getTotalCollateralUnit(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+  ): Promise<[Address, BigNumber]> {
+    const perpV2LeverageModuleViewerInstance = await this.contracts.loadPerpV2LeverageModuleViewerAsync(
+      this.perpV2LeverageModuleViewerAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleViewerInstance.getTotalCollateralUnit(
+      setTokenAddress,
+    );
+  }
+
+  /**
+   * Returns relevant data for displaying current positions. Identifying info for each position plus current
+   * size, index price, and leverage of each vAsset with an open position is returned. The sum quantity of vUSDC
+   * is returned along with identifying info in last index of array.
+   *
+   * @param setTokenAddress           Instance of the SetToken
+   * @param callerAddress             Address of the method caller
+   *
+   * @return                          Array of info concerning size and leverage of current vAsset positions
+   */
+  public async getVirtualAssetsDisplayInfo(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+  ): Promise<VAssetDisplayInfo[]> {
+    const perpV2LeverageModuleViewerInstance = await this.contracts.loadPerpV2LeverageModuleViewerAsync(
+      this.perpV2LeverageModuleViewerAddress,
+      callerAddress
+    );
+
+    return await perpV2LeverageModuleViewerInstance.getVirtualAssetsDisplayInfo(
+      setTokenAddress,
+    );
+  }
+}

--- a/src/wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper.ts
+++ b/src/wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper.ts
@@ -14,10 +14,8 @@
 'use strict';
 
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
-import { BigNumber, ContractTransaction } from 'ethers';
-import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { BigNumber } from 'ethers';
 import { Provider } from '@ethersproject/providers';
-import { generateTxOpts } from '../../utils/transactions';
 import { VAssetDisplayInfo } from '../../types';
 
 import ContractWrapper from './ContractWrapper';
@@ -39,30 +37,6 @@ export default class PerpV2LeverageModuleViewerWrapper {
     this.provider = provider;
     this.contracts = new ContractWrapper(this.provider);
     this.perpV2LeverageModuleViewerAddress = perpV2LeverageModuleViewerAddress;
-  }
-
-  /**
-   * Initializes this module to the SetToken. Only callable by the SetToken's manager.
-   *
-   * @param setTokenAddress             Address of the SetToken to initialize
-   * @param callerAddress               Address of caller (optional)
-   * @param txOpts                      Overrides for transaction (optional)
-   */
-  public async initialize(
-    setTokenAddress: Address,
-    callerAddress: Address = undefined,
-    txOpts: TransactionOverrides = {}
-  ): Promise<ContractTransaction> {
-    const txOptions = await generateTxOpts(txOpts);
-    const perpV2LeverageModuleViewerInstance = await this.contracts.loadPerpV2LeverageModuleViewerAsync(
-      this.perpV2LeverageModuleViewerAddress,
-      callerAddress
-    );
-
-    return await perpV2LeverageModuleViewerInstance.initialize(
-      setTokenAddress,
-      txOptions,
-    );
   }
 
   /**
@@ -94,7 +68,7 @@ export default class PerpV2LeverageModuleViewerWrapper {
    * @param slippage                  Expected slippage from entering position in precise units (1% = 10^16)
    * @param callerAddress             Address of the method caller
    *
-   * @return                          Maximum amount of Sets that can be issued
+   * @return                          Maximum amount of Sets that can be issued (10^18 decimals)
    */
   public async getMaximumSetTokenIssueAmount(
     setTokenAddress: Address,
@@ -119,7 +93,7 @@ export default class PerpV2LeverageModuleViewerWrapper {
    * @param callerAddress             Address of the method caller
    *
    * @return                          Collateral token address
-   * @return                          Total collateral value position unit
+   * @return                          Total collateral value position unit (10^18 decimals)
    */
   public async getTotalCollateralUnit(
     setTokenAddress: Address,
@@ -143,7 +117,7 @@ export default class PerpV2LeverageModuleViewerWrapper {
    * @param setTokenAddress           Instance of the SetToken
    * @param callerAddress             Address of the method caller
    *
-   * @return                          Array of info concerning size and leverage of current vAsset positions
+   * @return                          VAssetDisplayInfo array containing size/leverage of current vAsset positions
    */
   public async getVirtualAssetsDisplayInfo(
     setTokenAddress: Address,

--- a/src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper.ts
+++ b/src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper.ts
@@ -82,23 +82,6 @@ export default class PerpV2LeverageModuleWrapper {
   }
 
   /**
-   * Gets decimals of the collateral token
-   *
-   * @param  callerAddress            Address of the method caller
-   * @return                          The decimals of the ERC20 collateral token
-   */
-  public async collateralDecimals(
-    callerAddress: Address = undefined,
-  ): Promise<Number> {
-    const perpV2LeverageModuleInstance = await this.contracts.loadPerpV2LeverageModuleAsync(
-      this.perpV2LeverageModuleAddress,
-      callerAddress
-    );
-
-    return await perpV2LeverageModuleInstance.collateralDecimals();
-  }
-
-  /**
    * Returns a tuple of arrays representing all positions open for the SetToken.
    *
    * @param _setToken                 Instance of SetToken

--- a/test/api/PerpV2LeverageViewerAPI.spec.ts
+++ b/test/api/PerpV2LeverageViewerAPI.spec.ts
@@ -17,36 +17,38 @@
 import { ethers } from 'ethers';
 import { BigNumber, ContractTransaction } from 'ethers/lib/ethers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ether } from '@setprotocol/set-protocol-v2/dist/utils/common';
+import { VAssetDisplayInfo } from '@src/types';
 
-import PerpV2LeverageAPI from '@src/api/PerpV2LeverageAPI';
-import PerpV2LeverageModuleWrapper from '@src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper';
+import PerpV2LeverageViewerAPI from '@src/api/PerpV2LeverageViewerAPI';
+import PerpV2LeverageModuleViewerWrapper from '@src/wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper';
 import { expect } from '../utils/chai';
 
 const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
 
-jest.mock('@src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper');
+jest.mock('@src/wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper');
 
-describe('PerpV2LeverageAPI', () => {
-  let perpV2LeverageModuleAddress: Address;
+describe('PerpV2LeverageViewerAPI', () => {
+  let perpV2LeverageModuleViewerAddress: Address;
   let setTokenAddress: Address;
   let owner: Address;
 
-  let perpV2LeverageAPI: PerpV2LeverageAPI;
-  let perpV2LeverageModuleWrapper: PerpV2LeverageModuleWrapper;
+  let perpV2LeverageViewerAPI: PerpV2LeverageViewerAPI;
+  let perpV2LeverageModuleViewerWrapper: PerpV2LeverageModuleViewerWrapper;
 
   beforeEach(async () => {
     [
       owner,
-      perpV2LeverageModuleAddress,
+      perpV2LeverageModuleViewerAddress,
       setTokenAddress,
     ] = await provider.listAccounts();
 
-    perpV2LeverageAPI = new PerpV2LeverageAPI(provider, perpV2LeverageModuleAddress);
-    perpV2LeverageModuleWrapper = (PerpV2LeverageModuleWrapper as any).mock.instances[0];
+    perpV2LeverageViewerAPI = new PerpV2LeverageViewerAPI(provider, perpV2LeverageModuleViewerAddress);
+    perpV2LeverageModuleViewerWrapper = (PerpV2LeverageModuleViewerWrapper as any).mock.instances[0];
   });
 
   afterEach(() => {
-    (PerpV2LeverageModuleWrapper as any).mockClear();
+    (PerpV2LeverageModuleViewerWrapper as any).mockClear();
   });
 
   describe('#initializeAsync', () => {
@@ -62,17 +64,17 @@ describe('PerpV2LeverageAPI', () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return perpV2LeverageAPI.initializeAsync(
+      return perpV2LeverageViewerAPI.initializeAsync(
         subjectSetTokenAddress,
         subjectCallerAddress,
         subjectTransactionOptions,
       );
     }
 
-    it('should call initialize on the PerpV2LeverageModuleWrapper', async () => {
+    it('should call initialize on the PerpV2LeverageModuleViewerWrapper', async () => {
       await subject();
 
-      expect(perpV2LeverageModuleWrapper.initialize).to.have.beenCalledWith(
+      expect(perpV2LeverageModuleViewerWrapper.initialize).to.have.beenCalledWith(
         subjectSetTokenAddress,
         subjectCallerAddress,
         subjectTransactionOptions,
@@ -88,38 +90,41 @@ describe('PerpV2LeverageAPI', () => {
     });
 
     async function subject(): Promise<string> {
-      return await perpV2LeverageAPI.getCollateralTokenAsync(
+      return await perpV2LeverageViewerAPI.getCollateralTokenAsync(
         nullCallerAddress,
       );
     }
 
-    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+    it('should call the PerpV2LeverageModuleViewerWrapper with correct params', async () => {
       await subject();
 
-      expect(perpV2LeverageModuleWrapper.collateralToken).to.have.beenCalledWith(nullCallerAddress);
+      expect(perpV2LeverageModuleViewerWrapper.collateralToken).to.have.beenCalledWith(nullCallerAddress);
     });
   });
 
-  describe('#getPositionNotionalInfoAsync', () => {
+  describe('#getMaximumSetTokenIssueAmountAsync', () => {
     let subjectTokenAddress: Address;
+    let slippage: BigNumber;
     let nullCallerAddress: Address;
 
     beforeEach(async () => {
       subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      slippage = ether(2);
       nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
-    async function subject(): Promise<(Address|BigNumber)[][]> {
-      return await perpV2LeverageAPI.getPositionNotionalInfoAsync(
+    async function subject(): Promise<BigNumber> {
+      return await perpV2LeverageViewerAPI.getMaximumSetTokenIssueAmountAsync(
         subjectTokenAddress,
+        slippage,
         nullCallerAddress,
       );
     }
 
-    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+    it('should call the PerpV2LeverageModuleViewerWrapper with correct params', async () => {
       await subject();
 
-      expect(perpV2LeverageModuleWrapper.getPositionNotionalInfo).to.have.beenCalledWith(
+      expect(perpV2LeverageModuleViewerWrapper.getMaximumSetTokenIssueAmount).to.have.beenCalledWith(
         subjectTokenAddress,
         nullCallerAddress,
       );
@@ -136,7 +141,7 @@ describe('PerpV2LeverageAPI', () => {
     });
   });
 
-  describe('#getPositionUnitInfoAsync', () => {
+  describe('#getTotalCollateralUnitAsync', () => {
     let subjectTokenAddress: Address;
     let nullCallerAddress: Address;
 
@@ -145,17 +150,17 @@ describe('PerpV2LeverageAPI', () => {
       nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
-    async function subject(): Promise<(Address|BigNumber)[][]> {
-      return await perpV2LeverageAPI.getPositionUnitInfoAsync(
+    async function subject(): Promise<[Address, BigNumber]> {
+      return await perpV2LeverageViewerAPI.getTotalCollateralUnitAsync(
         subjectTokenAddress,
         nullCallerAddress,
       );
     }
 
-    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+    it('should call the PerpV2LeverageModuleViewerWrapper with correct params', async () => {
       await subject();
 
-      expect(perpV2LeverageModuleWrapper.getPositionUnitInfo).to.have.beenCalledWith(
+      expect(perpV2LeverageModuleViewerWrapper.getTotalCollateralUnit).to.have.beenCalledWith(
         subjectTokenAddress,
         nullCallerAddress,
       );
@@ -172,7 +177,7 @@ describe('PerpV2LeverageAPI', () => {
     });
   });
 
-  describe('#getAccountInfoAsync', () => {
+  describe('#getVirtualAssetsDisplayInfoAsync', () => {
     let subjectTokenAddress: Address;
     let nullCallerAddress: Address;
 
@@ -181,17 +186,20 @@ describe('PerpV2LeverageAPI', () => {
       nullCallerAddress = '0x0000000000000000000000000000000000000000';
     });
 
-    async function subject(): Promise<BigNumber[]> {
-      return await perpV2LeverageAPI.getAccountInfoAsync(
+    async function subject(): Promise<VAssetDisplayInfo[]> {
+      return await perpV2LeverageViewerAPI.getVirtualAssetsDisplayInfoAsync(
         subjectTokenAddress,
         nullCallerAddress,
       );
     }
 
-    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+    it('should call the PerpV2LeverageModuleViewerWrapper with correct params', async () => {
       await subject();
 
-      expect(perpV2LeverageModuleWrapper.getAccountInfo).to.have.beenCalledWith(subjectTokenAddress, nullCallerAddress);
+      expect(perpV2LeverageModuleViewerWrapper.getVirtualAssetsDisplayInfo).to.have.beenCalledWith(
+        subjectTokenAddress,
+        nullCallerAddress,
+      );
     });
 
     describe('when the SetToken address is invalid', () => {

--- a/test/api/PerpV2LeverageViewerAPI.spec.ts
+++ b/test/api/PerpV2LeverageViewerAPI.spec.ts
@@ -15,7 +15,7 @@
 */
 
 import { ethers } from 'ethers';
-import { BigNumber, ContractTransaction } from 'ethers/lib/ethers';
+import { BigNumber } from 'ethers/lib/ethers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { ether } from '@setprotocol/set-protocol-v2/dist/utils/common';
 import { VAssetDisplayInfo } from '@src/types';
@@ -30,17 +30,13 @@ jest.mock('@src/wrappers/set-protocol-v2/PerpV2LeverageModuleViewerWrapper');
 
 describe('PerpV2LeverageViewerAPI', () => {
   let perpV2LeverageModuleViewerAddress: Address;
-  let setTokenAddress: Address;
-  let owner: Address;
 
   let perpV2LeverageViewerAPI: PerpV2LeverageViewerAPI;
   let perpV2LeverageModuleViewerWrapper: PerpV2LeverageModuleViewerWrapper;
 
   beforeEach(async () => {
     [
-      owner,
       perpV2LeverageModuleViewerAddress,
-      setTokenAddress,
     ] = await provider.listAccounts();
 
     perpV2LeverageViewerAPI = new PerpV2LeverageViewerAPI(provider, perpV2LeverageModuleViewerAddress);
@@ -49,37 +45,6 @@ describe('PerpV2LeverageViewerAPI', () => {
 
   afterEach(() => {
     (PerpV2LeverageModuleViewerWrapper as any).mockClear();
-  });
-
-  describe('#initializeAsync', () => {
-    let subjectSetTokenAddress: Address;
-    let subjectCallerAddress: Address;
-
-    let subjectTransactionOptions: any;
-
-    beforeEach(async () => {
-      subjectSetTokenAddress = setTokenAddress;
-      subjectCallerAddress = owner;
-      subjectTransactionOptions = {};
-    });
-
-    async function subject(): Promise<ContractTransaction> {
-      return perpV2LeverageViewerAPI.initializeAsync(
-        subjectSetTokenAddress,
-        subjectCallerAddress,
-        subjectTransactionOptions,
-      );
-    }
-
-    it('should call initialize on the PerpV2LeverageModuleViewerWrapper', async () => {
-      await subject();
-
-      expect(perpV2LeverageModuleViewerWrapper.initialize).to.have.beenCalledWith(
-        subjectSetTokenAddress,
-        subjectCallerAddress,
-        subjectTransactionOptions,
-      );
-    });
   });
 
   describe('#getCollateralTokenAsync', () => {
@@ -126,6 +91,7 @@ describe('PerpV2LeverageViewerAPI', () => {
 
       expect(perpV2LeverageModuleViewerWrapper.getMaximumSetTokenIssueAmount).to.have.beenCalledWith(
         subjectTokenAddress,
+        slippage,
         nullCallerAddress,
       );
     });

--- a/test/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper.spec.ts
+++ b/test/wrappers/set-protocol-v2/DebtIssuanceModuleV2Wrapper.spec.ts
@@ -63,7 +63,7 @@ describe('DebtIssuanceModuleV2Wrapper', () => {
 
     debtIssuanceModuleV2 = await deployer.modules.deployDebtIssuanceModuleV2(setup.controller.address);
     tokenWithRoundingError = await deployer.mocks.deployTokenWithErrorMock(owner, ether(1000000), ZERO);
-    debtModule = await deployer.mocks.deployDebtModuleMock(setup.controller.address, debtIssuanceModuleV2.address);
+    debtModule = await deployer.mocks.deployDebtModuleMock(setup.controller.address);
     externalPositionModule = await deployer.mocks.deployModuleIssuanceHookMock();
 
     await setup.controller.addModule(debtIssuanceModuleV2.address);
@@ -459,7 +459,10 @@ describe('DebtIssuanceModuleV2Wrapper', () => {
           recipient,
           preIssueHook
         );
-        await debtModule.connect(provider.getSigner(manager)).initialize(setTokenWithRoundingError.address);
+        await debtModule.connect(provider.getSigner(manager)).initialize(
+          setTokenWithRoundingError.address,
+          debtIssuanceModuleV2.address,
+        );
         await debtModule.addDebt(setTokenWithRoundingError.address, setup.dai.address, debtUnits);
         await setup.dai.transfer(debtModule.address, ether(100.5));
 

--- a/test/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.spec.ts
+++ b/test/wrappers/set-protocol-v2/SlippageIssuanceModuleWrapper.spec.ts
@@ -67,7 +67,7 @@ describe('SlippageIssuanceModuleWrapper', () => {
     await setup.initialize();
 
     slippageIssuanceModule = await deployer.modules.deploySlippageIssuanceModule(setup.controller.address);
-    debtModule = await deployer.mocks.deployDebtModuleMock(setup.controller.address, slippageIssuanceModule.address);
+    debtModule = await deployer.mocks.deployDebtModuleMock(setup.controller.address);
     externalPositionModule = await deployer.mocks.deployModuleIssuanceHookMock();
 
     await setup.controller.addModule(slippageIssuanceModule.address);
@@ -245,7 +245,10 @@ describe('SlippageIssuanceModuleWrapper', () => {
         subjectManagerIssuanceHook,
       );
 
-      await debtModule.connect(provider.getSigner(manager)).initialize(setToken.address);
+      await debtModule.connect(provider.getSigner(manager)).initialize(
+        setToken.address,
+        slippageIssuanceModule.address,
+      );
 
       await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
       await setup.dai.transfer(debtModule.address, ether(100.5));
@@ -324,7 +327,10 @@ describe('SlippageIssuanceModuleWrapper', () => {
         subjectManagerIssuanceHook,
       );
 
-      await debtModule.connect(provider.getSigner(manager)).initialize(setToken.address);
+      await debtModule.connect(provider.getSigner(manager)).initialize(
+        setToken.address,
+        slippageIssuanceModule.address,
+      );
 
       await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
       await setup.dai.transfer(debtModule.address, ether(100.5));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,10 +1016,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@setprotocol/set-protocol-v2@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.9.tgz#1b0eef8667d01405f0b259bc5129986e5db7b53b"
-  integrity sha512-sPbCD6ngw4yIosXyOT+ytFZbFeMyHNOgDA6hdhrXkllsSKoJ2thc9Y6SqzF5kCPkK+bKmVhNF+cMTDMX0lemZg==
+"@setprotocol/set-protocol-v2@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.10.tgz#a8135e3e57cbdb857392bcf3cfe98d23bdc91333"
+  integrity sha512-PoDRg+ZeNk7eATvfqPxe1yMLTFoIgAfGA8oUmC8FTIM7F5Ya6wJCpzoJFaLcbd3lWK9+GUkoh6D1onLCatU5hw==
   dependencies:
     "@uniswap/v3-sdk" "^3.5.1"
     ethers "^5.5.2"


### PR DESCRIPTION
New PerpV2LeverageViewerAPI for the upcoming contract that will abstract a lot of data getters out of the existing PerpV2LeverageModule.

Relevant smart contract PR: https://github.com/SetProtocol/set-protocol-v2/pull/185