### PR TITLE
Add isSet getter to the SystemAPI Controller contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.11",
+    "version": "0.4.12",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/api/SystemAPI.ts
+++ b/src/api/SystemAPI.ts
@@ -71,4 +71,14 @@ export default class SystemAPI {
   public async getSetsAsync(callerAddress?: Address): Promise<Address[]> {
     return await this.controllerWrapper.getSets(callerAddress);
   }
+
+  /**
+   * Returns whether or not an address is a SetToken
+   *
+   * @param address            Address to check
+   * @return                   boolean
+   */
+  public async isSetAsync(address, callerAddress?: Address): Promise<boolean> {
+    return await this.controllerWrapper.isSet(address, callerAddress);
+  }
 }

--- a/src/wrappers/set-protocol-v2/ContractWrapper.ts
+++ b/src/wrappers/set-protocol-v2/ContractWrapper.ts
@@ -77,8 +77,9 @@ export default class ContractWrapper {
    */
   public async loadControllerContractAsync(
     controllerAddress: Address,
-    signer: Signer,
+    callerAddress?: Address,
   ): Promise<Controller> {
+    const signer = (this.provider as JsonRpcProvider).getSigner(callerAddress);
     const cacheKey = `Controller_${controllerAddress}_${await signer.getAddress()}`;
 
     if (cacheKey in this.cache) {

--- a/src/wrappers/set-protocol-v2/ControllerWrapper.ts
+++ b/src/wrappers/set-protocol-v2/ControllerWrapper.ts
@@ -16,7 +16,7 @@
 
 'use strict';
 
-import { Provider, JsonRpcProvider } from '@ethersproject/providers';
+import { Provider } from '@ethersproject/providers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 
 import ContractWrapper from './ContractWrapper';
@@ -36,7 +36,7 @@ export default class ControllerWrapper {
 
   public constructor(provider: Provider, controllerAddress: Address) {
     this.provider = provider;
-    this.contracts = new ContractWrapper(provider);
+    this.contracts = new ContractWrapper(this.provider);
     this.controllerAddress = controllerAddress;
   }
 
@@ -51,7 +51,7 @@ export default class ControllerWrapper {
   ): Promise<Address[]> {
     const controller = await this.contracts.loadControllerContractAsync(
       this.controllerAddress,
-      (this.provider as JsonRpcProvider).getSigner(callerAddress)
+      callerAddress,
     );
 
     return controller.getFactories();
@@ -68,7 +68,7 @@ export default class ControllerWrapper {
   ): Promise<Address[]> {
     const controller = await this.contracts.loadControllerContractAsync(
       this.controllerAddress,
-      (this.provider as JsonRpcProvider).getSigner(callerAddress)
+      callerAddress,
     );
 
     return controller.getModules();
@@ -85,7 +85,7 @@ export default class ControllerWrapper {
   ): Promise<Address[]> {
     const controller = await this.contracts.loadControllerContractAsync(
       this.controllerAddress,
-      (this.provider as JsonRpcProvider).getSigner(callerAddress)
+      callerAddress,
     );
 
     return controller.getResources();
@@ -102,9 +102,27 @@ export default class ControllerWrapper {
   ): Promise<Address[]> {
     const controller = await this.contracts.loadControllerContractAsync(
       this.controllerAddress,
-      (this.provider as JsonRpcProvider).getSigner(callerAddress)
+      callerAddress,
     );
 
     return controller.getSets();
+  }
+
+  /**
+   * Returns whether or not an address is a SetToken
+   *
+   * @param address            Address to check
+   * @return                   boolean
+   */
+  public async isSet(
+    address: Address,
+    callerAddress?: Address,
+  ): Promise<boolean> {
+    const controller = await this.contracts.loadControllerContractAsync(
+      this.controllerAddress,
+      callerAddress,
+    );
+
+    return controller.isSet(address);
   }
 }

--- a/test/api/SystemAPI.spec.ts
+++ b/test/api/SystemAPI.spec.ts
@@ -91,4 +91,27 @@ describe('SystemAPI', () => {
       expect(controllerWrapper.getSets).to.have.beenCalled;
     });
   });
+
+  describe('#isSetAsync', () => {
+    let subjectAddress: Address;
+    let nullCallerAddress: Address;
+
+    beforeEach(async () => {
+      subjectAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
+    });
+
+    async function subject(): Promise<boolean> {
+      return await systemAPI.isSetAsync(subjectAddress, nullCallerAddress);
+    }
+
+    it('should call the ControllerWrapper with correct params', async () => {
+      await subject();
+
+      expect(controllerWrapper.isSet).to.have.beenCalledWith(
+        subjectAddress,
+        nullCallerAddress,
+      );
+    });
+  });
 });

--- a/test/wrappers/set-protocol-v2/ControllerWrapper.spec.ts
+++ b/test/wrappers/set-protocol-v2/ControllerWrapper.spec.ts
@@ -185,4 +185,37 @@ describe('ControllerWrapper', () => {
       });
     });
   });
+
+  describe('#isSet', () => {
+    let subjectCaller: Address;
+
+    beforeEach(async () => {
+      subjectCaller = functionCaller;
+    });
+
+    async function subject(): Promise<boolean> {
+      return controllerWrapper.isSet(mockSetTokenAddress, subjectCaller);
+    }
+
+    it('returns false', async () => {
+      const isSet = await subject();
+
+      expect(isSet).to.eq(false);
+    });
+
+    describe('when the SetToken is added to the factory', () => {
+      beforeEach(async () => {
+        await controller.addFactory(mockSetTokenFactory);
+
+        controller = controller.connect(provider.getSigner(mockSetTokenFactory));
+        await controller.addSet(mockSetTokenAddress);
+      });
+
+      it('returns true', async () => {
+        const isSet = await subject();
+
+        expect(isSet).to.eq(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This will allow for clients such as our Tokensets UI to be able to make decisions on what to display based on whether components are subsets or traditional ERC20s.