### PR TITLE
Add DelegatedManagerSystem API 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.13-managerV3.3",
+    "version": "0.4.13-managerV3.2",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
         "@setprotocol/set-protocol-v2": "^0.1.15",
-        "@setprotocol/set-v2-strategies": "^0.0.5",
+        "@setprotocol/set-v2-strategies": "^0.0.6",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.5.2-managerV3.1",
+    "version": "0.5.2",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.13-managerV3.2",
+    "version": "0.4.2-managerV3.0",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
         "@setprotocol/set-protocol-v2": "^0.1.10",
-        "@setprotocol/set-v2-strategies": "^0.0.4",
+        "@setprotocol/set-v2-strategies": "^0.0.5",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.2-managerV3.0",
+    "version": "0.5.2-managerV3.0",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",
@@ -59,7 +59,7 @@
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
         "@setprotocol/set-protocol-v2": "^0.1.15",
-        "@setprotocol/set-v2-strategies": "^0.0.6",
+        "@setprotocol/set-v2-strategies": "^0.0.7",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
         "@setprotocol/set-protocol-v2": "^0.1.10",
+        "@setprotocol/set-v2-strategies": "^0.0.4",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",
         "@types/web3": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.5.2-managerV3.0",
+    "version": "0.5.2-managerV3.1",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.13-managerV3.0",
+    "version": "0.4.13-managerV3.1",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@0xproject/types": "^1.1.4",
         "@0xproject/typescript-typings": "^3.0.2",
         "@0xproject/utils": "^2.0.2",
-        "@setprotocol/set-protocol-v2": "^0.1.10",
+        "@setprotocol/set-protocol-v2": "^0.1.15",
         "@setprotocol/set-v2-strategies": "^0.0.5",
         "@types/chai-as-promised": "^7.1.3",
         "@types/jest": "^26.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.13-managerV3.2",
+    "version": "0.4.13-managerV3.3",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.4.13-managerV3.1",
+    "version": "0.4.13-managerV3.2",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.5.1",
+    "version": "0.4.13-managerV3.0",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -16,7 +16,7 @@
 
 'use strict';
 
-import { SetJSConfig } from './types';
+import { SetJSConfig, DelegatedManagerSystemExtensions } from './types';
 import Assertions from './assertions';
 import {
   BlockchainAPI,
@@ -34,6 +34,9 @@ import {
   PerpV2LeverageAPI,
   PerpV2LeverageViewerAPI,
   UtilsAPI,
+  IssuanceExtensionAPI,
+  TradeExtensionAPI,
+  StreamingFeeExtensionAPI,
 } from './api/index';
 
 const ethersProviders = require('ethers').providers;
@@ -147,6 +150,12 @@ class Set {
    */
   public blockchain: BlockchainAPI;
 
+
+  /**
+   * Group of extension for interacting with SetTokens managed by with DelegatedManager system contracts
+   */
+  public extensions: DelegatedManagerSystemExtensions;
+
   /**
    * An instance of the UtilsAPI class. Contains interfaces for fetching swap quotes from 0x Protocol,
    * prices and token metadata from coingecko, and network gas prices from various sources
@@ -187,6 +196,12 @@ class Set {
                                                                 config.perpV2BasisTradingModuleViewerAddress);
     this.blockchain = new BlockchainAPI(ethersProvider, assertions);
     this.utils = new UtilsAPI(ethersProvider, config.zeroExApiKey, config.zeroExApiUrls);
+
+    this.extensions = {
+      streamingFeeExtension: new StreamingFeeExtensionAPI(ethersProvider, config.streamingFeeExtensionAddress),
+      issuanceExtension: new IssuanceExtensionAPI(ethersProvider, config.issuanceExtensionAddress),
+      tradeExtension: new TradeExtensionAPI(ethersProvider, config.tradeExtensionAddress),
+    };
   }
 }
 

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -113,6 +113,14 @@ class Set {
   public debtIssuanceV2: DebtIssuanceV2API;
 
   /**
+   * An instance of the DebtIssuanceV2API class. Contains interfaces for interacting
+   * with the IssuanceModule contract (an alternatively named DebtIssuanceV2 module instance)
+   * to issue and redeem tokens that accrue interest. Primarily used for contracts deployed via
+   * the DelegatedManagerSystem
+   */
+  public issuanceV2: DebtIssuanceV2API;
+
+  /**
    * An instance of the SlippageIssuanceAPI class. Contains interfaces for interacting
    * with the SlippageIssuanceAPI contract to to trade into/from tokens during the issuance and
    * redemption step. Initially used for Perpetual Leverage Tokens.
@@ -194,6 +202,7 @@ class Set {
     this.priceOracle = new PriceOracleAPI(ethersProvider, config.masterOracleAddress);
     this.debtIssuance = new DebtIssuanceAPI(ethersProvider, config.debtIssuanceModuleAddress);
     this.debtIssuanceV2 = new DebtIssuanceV2API(ethersProvider, config.debtIssuanceModuleV2Address);
+    this.issuanceV2 = new DebtIssuanceV2API(ethersProvider, config.issuanceModuleAddress);
     this.slippageIssuance = new SlippageIssuanceAPI(ethersProvider, config.slippageIssuanceModuleAddress);
     this.perpV2Leverage = new PerpV2LeverageAPI(ethersProvider, config.perpV2LeverageModuleAddress);
     this.perpV2LeverageViewer = new PerpV2LeverageViewerAPI(ethersProvider, config.perpV2LeverageModuleViewerAddress);

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -34,6 +34,7 @@ import {
   PerpV2LeverageAPI,
   PerpV2LeverageViewerAPI,
   UtilsAPI,
+  DelegatedManagerFactoryAPI,
   IssuanceExtensionAPI,
   TradeExtensionAPI,
   StreamingFeeExtensionAPI,
@@ -145,11 +146,10 @@ class Set {
   public perpV2BasisTradingViewer: PerpV2LeverageViewerAPI;
 
   /**
-   * An instance of the BlockchainAPI class. Contains interfaces for
-   * interacting with the blockchain
+   * An instance of DelegatedManagerFactory class. Contains methods for deploying and initializing
+   * DelegatedManagerSystem deployed SetTokens and Manager contracts
    */
-  public blockchain: BlockchainAPI;
-
+  public delegatedManagerFactory: DelegatedManagerFactoryAPI;
 
   /**
    * Group of extension for interacting with SetTokens managed by with DelegatedManager system contracts
@@ -161,6 +161,12 @@ class Set {
    * prices and token metadata from coingecko, and network gas prices from various sources
    */
   public utils: UtilsAPI;
+
+  /**
+   * An instance of the BlockchainAPI class. Contains interfaces for
+   * interacting with the blockchain
+   */
+  public blockchain: BlockchainAPI;
 
   /**
    * Instantiates a new Set instance that provides the public interface to the Set.js library
@@ -196,6 +202,11 @@ class Set {
                                                                 config.perpV2BasisTradingModuleViewerAddress);
     this.blockchain = new BlockchainAPI(ethersProvider, assertions);
     this.utils = new UtilsAPI(ethersProvider, config.zeroExApiKey, config.zeroExApiUrls);
+
+    this.delegatedManagerFactory = new DelegatedManagerFactoryAPI(
+      ethersProvider,
+      config.delegatedManagerFactoryAddress
+    );
 
     this.extensions = {
       streamingFeeExtension: new StreamingFeeExtensionAPI(ethersProvider, config.streamingFeeExtensionAddress),

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -113,14 +113,6 @@ class Set {
   public debtIssuanceV2: DebtIssuanceV2API;
 
   /**
-   * An instance of the DebtIssuanceV2API class. Contains interfaces for interacting
-   * with the IssuanceModule contract (an alternatively named DebtIssuanceV2 module instance)
-   * to issue and redeem tokens that accrue interest. Primarily used for contracts deployed via
-   * the DelegatedManagerSystem
-   */
-  public issuanceV2: DebtIssuanceV2API;
-
-  /**
    * An instance of the SlippageIssuanceAPI class. Contains interfaces for interacting
    * with the SlippageIssuanceAPI contract to to trade into/from tokens during the issuance and
    * redemption step. Initially used for Perpetual Leverage Tokens.
@@ -202,7 +194,6 @@ class Set {
     this.priceOracle = new PriceOracleAPI(ethersProvider, config.masterOracleAddress);
     this.debtIssuance = new DebtIssuanceAPI(ethersProvider, config.debtIssuanceModuleAddress);
     this.debtIssuanceV2 = new DebtIssuanceV2API(ethersProvider, config.debtIssuanceModuleV2Address);
-    this.issuanceV2 = new DebtIssuanceV2API(ethersProvider, config.issuanceModuleAddress);
     this.slippageIssuance = new SlippageIssuanceAPI(ethersProvider, config.slippageIssuanceModuleAddress);
     this.perpV2Leverage = new PerpV2LeverageAPI(ethersProvider, config.perpV2LeverageModuleAddress);
     this.perpV2LeverageViewer = new PerpV2LeverageViewerAPI(ethersProvider, config.perpV2LeverageModuleViewerAddress);

--- a/src/api/DelegatedManagerFactoryAPI.ts
+++ b/src/api/DelegatedManagerFactoryAPI.ts
@@ -163,6 +163,17 @@ export default class DelegatedManagerFactoryAPI {
     this.assert.schema.isValidAddressList('initializeTargets', initializeTargets);
     this.assert.schema.isValidBytesList('initializeBytecode', initializeBytecode);
 
+    this.assert.common.isNotEmptyArray(
+      initializeTargets,
+      'initializationTargets array must contain at least one element.'
+    );
+
+    this.assert.common.isEqualLength(
+      initializeTargets,
+      initializeBytecode,
+      'initializeTargets and initializeBytecode arrays must be equal length.'
+    );
+
     return await this.DelegatedManagerFactoryWrapper.initialize(
       setTokenAddress,
       ownerFeeSplit,

--- a/src/api/extensions/IssuanceExtensionAPI.ts
+++ b/src/api/extensions/IssuanceExtensionAPI.ts
@@ -54,14 +54,14 @@ export default class IssuanceExtensionAPI {
    * @param callerAddress        Address of caller (optional)
    * @param txOpts               Overrides for transaction (optional)
    */
-  public async distribute(
+  public async distributeFeesAsync(
     setTokenAddress: Address,
     callerAddress: Address = undefined,
     txOpts: TransactionOverrides = {}
   ): Promise<ContractTransaction> {
     this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
 
-    return await this.issuanceExtensionWrapper.distribute(
+    return await this.issuanceExtensionWrapper.distributeFees(
       setTokenAddress,
       callerAddress,
       txOpts
@@ -72,12 +72,7 @@ export default class IssuanceExtensionAPI {
    * Generates IssuanceExtension initialize call bytecode to be passed as an element in the  `initializeBytecode`
    * array for the DelegatedManagerFactory's `initializeAsync` method.
    *
-   * @param setTokenAddress              Instance of deployed setToken to initialize the IssuanceExtension for
-   * @param maxManagerFee                Maximum fee that can be charged on issue and redeem
-   * @param managerIssueFee              Fee to charge on issuance
-   * @param managerRedeemFee             Fee to charge on redemption
-   * @param feeRecipient                 Address to send fees to
-   * @param managerIssuanceHook          Address of contract implementing pre-issuance hook function (ex: SupplyCapHook)
+   * @param delegatedManagerAddress      Instance of DelegatedManager to initialize the StreamingFeeExtension for
    *
    * @return                             Initialization bytecode
    */
@@ -87,14 +82,19 @@ export default class IssuanceExtensionAPI {
     this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
 
     const moduleInterface = new EthersUtils.Interface(IssuanceExtension__factory.abi);
-    return moduleInterface.encodeFunctionData('initialize', [ delegatedManagerAddress ]);
+    return moduleInterface.encodeFunctionData('initializeExtension', [ delegatedManagerAddress ]);
   }
 
   /**
    * Generates IssuanceModule initialize call bytecode to be passed as an element in the  `initializeBytecode`
    * array for the `initializeAsync` method.
    *
-   * @param delegatedManagerAddress      Instance of deployed DelegatedManager to initialize the IssuanceExtension for
+   * @param delegatedManagerAddress      Instance of deployed setToken to initialize the IssuanceExtension for
+   * @param maxManagerFee                Maximum fee that can be charged on issue and redeem
+   * @param managerIssueFee              Fee to charge on issuance
+   * @param managerRedeemFee             Fee to charge on redemption
+   * @param feeRecipient                 Address to send fees to
+   * @param managerIssuanceHook          Address of contract implementing pre-issuance hook function (ex: SupplyCapHook)
    *
    * @return                             Initialization bytecode
    */

--- a/src/api/extensions/IssuanceExtensionAPI.ts
+++ b/src/api/extensions/IssuanceExtensionAPI.ts
@@ -1,0 +1,128 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { ContractTransaction, BigNumberish, BytesLike, utils as EthersUtils } from 'ethers';
+import { Provider } from '@ethersproject/providers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { IssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/IssuanceModule__factory';
+
+// @ts-ignore
+import { IssuanceExtension__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/IssuanceExtension__factory';
+
+import IssuanceExtensionWrapper from '../../wrappers/set-v2-strategies/IssuanceExtensionWrapper';
+import Assertions from '../../assertions';
+
+/**
+ * @title  IssuanceExtensionAPI
+ * @author Set Protocol
+ *
+ * The IssuanceExtensionAPI exposes methods to distribute and configure issuance fees for SetTokens
+ * using the DelegatedManager system. The API also provides some helper methods to generate bytecode data packets
+ * that encode module and extension initialization method calls.
+ */
+export default class IssuanceExtensionAPI {
+  private issuanceExtensionWrapper: IssuanceExtensionWrapper;
+  private assert: Assertions;
+
+  public constructor(
+    provider: Provider,
+    IssuanceExtensionAddress: Address,
+    assertions?: Assertions) {
+    this.issuanceExtensionWrapper = new IssuanceExtensionWrapper(provider, IssuanceExtensionAddress);
+    this.assert = assertions || new Assertions();
+  }
+
+  /**
+   * Distributes issuance and redemption fees calculates fees for. Calculates fees for owner and methodologist
+   * and sends to owner fee recipient and methodologist respectively. (Anyone can call this method.)
+   *
+   * @param setTokenAddress      Address of the deployed SetToken to distribute fees for
+   * @param callerAddress        Address of caller (optional)
+   * @param txOpts               Overrides for transaction (optional)
+   */
+  public async distribute(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+
+    return await this.issuanceExtensionWrapper.distribute(
+      setTokenAddress,
+      callerAddress,
+      txOpts
+    );
+  }
+
+  /**
+   * Generates IssuanceExtension initialize call bytecode to be passed as an element in the  `initializeBytecode`
+   * array for the DelegatedManagerFactory's `initializeAsync` method.
+   *
+   * @param setTokenAddress              Instance of deployed setToken to initialize the IssuanceExtension for
+   * @param maxManagerFee                Maximum fee that can be charged on issue and redeem
+   * @param managerIssueFee              Fee to charge on issuance
+   * @param managerRedeemFee             Fee to charge on redemption
+   * @param feeRecipient                 Address to send fees to
+   * @param managerIssuanceHook          Address of contract implementing pre-issuance hook function (ex: SupplyCapHook)
+   *
+   * @return                             Initialization bytecode
+   */
+  public getIssuanceExtensionInitializationBytecode(
+    delegatedManagerAddress: Address
+  ): BytesLike {
+    this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
+
+    const moduleInterface = new EthersUtils.Interface(IssuanceExtension__factory.abi);
+    return moduleInterface.encodeFunctionData('initialize', [ delegatedManagerAddress ]);
+  }
+
+  /**
+   * Generates IssuanceModule initialize call bytecode to be passed as an element in the  `initializeBytecode`
+   * array for the `initializeAsync` method.
+   *
+   * @param delegatedManagerAddress      Instance of deployed DelegatedManager to initialize the IssuanceExtension for
+   *
+   * @return                             Initialization bytecode
+   */
+  public getIssuanceModuleInitializationBytecode(
+    setTokenAddress: Address,
+    maxManagerFee: BigNumberish,
+    managerIssueFee: BigNumberish,
+    managerRedeemFee: BigNumberish,
+    feeRecipientAddress: Address,
+    managerIssuanceHookAddress: Address
+  ): BytesLike {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+    this.assert.schema.isValidNumber('maxManagerFee', maxManagerFee);
+    this.assert.schema.isValidNumber('managerIssueFee', managerIssueFee);
+    this.assert.schema.isValidNumber('managerRedeemFee', managerRedeemFee);
+    this.assert.schema.isValidAddress('feeRecipientAddress', feeRecipientAddress);
+    this.assert.schema.isValidAddress('managerIssuanceHookAddress', managerIssuanceHookAddress);
+
+    const moduleInterface = new EthersUtils.Interface(IssuanceModule__factory.abi);
+    return moduleInterface.encodeFunctionData('initialize', [
+      setTokenAddress,
+      maxManagerFee,
+      managerIssueFee,
+      managerRedeemFee,
+      feeRecipientAddress,
+      managerIssuanceHookAddress,
+    ]);
+  }
+}

--- a/src/api/extensions/IssuanceExtensionAPI.ts
+++ b/src/api/extensions/IssuanceExtensionAPI.ts
@@ -21,9 +21,7 @@ import { Provider } from '@ethersproject/providers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
 import { IssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/IssuanceModule__factory';
-
-// @ts-ignore
-import { IssuanceExtension__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/IssuanceExtension__factory';
+import { IssuanceExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/IssuanceExtension__factory';
 
 import IssuanceExtensionWrapper from '../../wrappers/set-v2-strategies/IssuanceExtensionWrapper';
 import Assertions from '../../assertions';

--- a/src/api/extensions/IssuanceExtensionAPI.ts
+++ b/src/api/extensions/IssuanceExtensionAPI.ts
@@ -20,7 +20,6 @@ import { ContractTransaction, BigNumberish, BytesLike, utils as EthersUtils } fr
 import { Provider } from '@ethersproject/providers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
-import { IssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/IssuanceModule__factory';
 import { IssuanceExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/IssuanceExtension__factory';
 
 import IssuanceExtensionWrapper from '../../wrappers/set-v2-strategies/IssuanceExtensionWrapper';
@@ -86,10 +85,10 @@ export default class IssuanceExtensionAPI {
   }
 
   /**
-   * Generates IssuanceModule initialize call bytecode to be passed as an element in the  `initializeBytecode`
-   * array for the `initializeAsync` method.
+   * Generates `moduleAndExtensionInitialization` bytecode to be passed as an element in the
+   * `initializeBytecode` array for the `initializeAsync` method.
    *
-   * @param delegatedManagerAddress      Instance of deployed setToken to initialize the IssuanceExtension for
+   * @param delegatedManagerAddress      Instance of deployed delegatedManager to initialize the IssuanceExtension for
    * @param maxManagerFee                Maximum fee that can be charged on issue and redeem
    * @param managerIssueFee              Fee to charge on issuance
    * @param managerRedeemFee             Fee to charge on redemption
@@ -98,24 +97,24 @@ export default class IssuanceExtensionAPI {
    *
    * @return                             Initialization bytecode
    */
-  public getIssuanceModuleInitializationBytecode(
-    setTokenAddress: Address,
+  public getIssuanceModuleAndExtensionInitializationBytecode(
+    delegatedManagerAddress: Address,
     maxManagerFee: BigNumberish,
     managerIssueFee: BigNumberish,
     managerRedeemFee: BigNumberish,
     feeRecipientAddress: Address,
     managerIssuanceHookAddress: Address
   ): BytesLike {
-    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
     this.assert.schema.isValidNumber('maxManagerFee', maxManagerFee);
     this.assert.schema.isValidNumber('managerIssueFee', managerIssueFee);
     this.assert.schema.isValidNumber('managerRedeemFee', managerRedeemFee);
     this.assert.schema.isValidAddress('feeRecipientAddress', feeRecipientAddress);
     this.assert.schema.isValidAddress('managerIssuanceHookAddress', managerIssuanceHookAddress);
 
-    const moduleInterface = new EthersUtils.Interface(IssuanceModule__factory.abi);
-    return moduleInterface.encodeFunctionData('initialize', [
-      setTokenAddress,
+    const moduleInterface = new EthersUtils.Interface(IssuanceExtension__factory.abi);
+    return moduleInterface.encodeFunctionData('initializeModuleAndExtension', [
+      delegatedManagerAddress,
       maxManagerFee,
       managerIssueFee,
       managerRedeemFee,

--- a/src/api/extensions/StreamingFeeExtensionAPI.ts
+++ b/src/api/extensions/StreamingFeeExtensionAPI.ts
@@ -18,6 +18,7 @@
 
 import { ContractTransaction, BytesLike, utils as EthersUtils } from 'ethers';
 import { Provider } from '@ethersproject/providers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
 import { Address, StreamingFeeState } from '@setprotocol/set-protocol-v2/utils/types';
 import { StreamingFeeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/StreamingFeeModule__factory';
 import { StreamingFeeSplitExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/StreamingFeeSplitExtension__factory';
@@ -51,13 +52,23 @@ export default class StreamingFeeExtensionAPI {
    * this method.)
    *
    * @param setTokenAddress      Instance of deployed SetToken to accrue & distribute streaming fees for
+   * @param callerAddress        Address of caller (optional)
+   * @param txOpts               Overrides for transaction (optional)
    *
    * @return                     Initialization bytecode
    */
-  public async accrueFeesAndDistribute(setTokenAddress: Address): Promise<ContractTransaction>  {
+  public async accrueFeesAndDistribute(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction>  {
     this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
 
-    return await this.streamingFeeExtensionWrapper.accrueFeesAndDistribute(setTokenAddress);
+    return await this.streamingFeeExtensionWrapper.accrueFeesAndDistribute(
+      setTokenAddress,
+      callerAddress,
+      txOpts
+    );
   }
 
   /**
@@ -74,7 +85,7 @@ export default class StreamingFeeExtensionAPI {
     this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
 
     const extensionInterface = new EthersUtils.Interface(StreamingFeeSplitExtension__factory.abi);
-    return extensionInterface.encodeFunctionData('initialize', [ delegatedManagerAddress ]);
+    return extensionInterface.encodeFunctionData('initializeExtension', [ delegatedManagerAddress ]);
   }
 
   /**

--- a/src/api/extensions/StreamingFeeExtensionAPI.ts
+++ b/src/api/extensions/StreamingFeeExtensionAPI.ts
@@ -20,7 +20,6 @@ import { ContractTransaction, BytesLike, utils as EthersUtils } from 'ethers';
 import { Provider } from '@ethersproject/providers';
 import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
 import { Address, StreamingFeeState } from '@setprotocol/set-protocol-v2/utils/types';
-import { StreamingFeeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/StreamingFeeModule__factory';
 import { StreamingFeeSplitExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/StreamingFeeSplitExtension__factory';
 
 import StreamingFeeExtensionWrapper from '../../wrappers/set-v2-strategies/StreamingFeeExtensionWrapper';
@@ -89,8 +88,8 @@ export default class StreamingFeeExtensionAPI {
   }
 
   /**
-   * Generates StreamingFeeModule initialize call bytecode to be passed as an element in the  `initializeBytecode`
-   * array for the `initializeAsync` method.
+   * Generates `moduleAndExtensionInitialization` bytecode to be passed as an element in the
+   * `initializeBytecode` array for the `initializeAsync` method.
    *
    * FeeSettings is an object with the properties:
    * ```
@@ -106,17 +105,20 @@ export default class StreamingFeeExtensionAPI {
    *
    * @return                            Initialization bytecode
    */
-  public getStreamingFeeModuleInitializationBytecode(
-    setTokenAddress: Address,
+  public getStreamingFeeModuleAndExtensionInitializationBytecode(
+    delegatedManagerAddress: Address,
     feeSettings: StreamingFeeState
   ): BytesLike {
-    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
     this.assert.schema.isValidAddress('feeSettings.feeRecipient', feeSettings.feeRecipient);
     this.assert.schema.isValidNumber('feeSettings.maxStreamingFeePercentage', feeSettings.maxStreamingFeePercentage);
     this.assert.schema.isValidNumber('feeSettings.streamingFeePercentage', feeSettings.streamingFeePercentage);
     this.assert.schema.isValidNumber('feeSettings.lastStreamingFeeTimestamp', feeSettings.lastStreamingFeeTimestamp);
 
-    const moduleInterface = new EthersUtils.Interface(StreamingFeeModule__factory.abi);
-    return moduleInterface.encodeFunctionData('initialize', [ setTokenAddress, feeSettings ]);
+    const extensionInterface = new EthersUtils.Interface(StreamingFeeSplitExtension__factory.abi);
+    return extensionInterface.encodeFunctionData('initializeModuleAndExtension', [
+      delegatedManagerAddress,
+      feeSettings,
+    ]);
   }
 }

--- a/src/api/extensions/StreamingFeeExtensionAPI.ts
+++ b/src/api/extensions/StreamingFeeExtensionAPI.ts
@@ -57,7 +57,7 @@ export default class StreamingFeeExtensionAPI {
    *
    * @return                     Initialization bytecode
    */
-  public async accrueFeesAndDistribute(
+  public async accrueFeesAndDistributeAsync(
     setTokenAddress: Address,
     callerAddress: Address = undefined,
     txOpts: TransactionOverrides = {}

--- a/src/api/extensions/StreamingFeeExtensionAPI.ts
+++ b/src/api/extensions/StreamingFeeExtensionAPI.ts
@@ -1,0 +1,113 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { ContractTransaction, BytesLike, utils as EthersUtils } from 'ethers';
+import { Provider } from '@ethersproject/providers';
+import { Address, StreamingFeeState } from '@setprotocol/set-protocol-v2/utils/types';
+import { StreamingFeeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/StreamingFeeModule__factory';
+
+// @ts-ignore
+import { StreamingFeeSplitExtension__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/StreamingFeeSplitExtension__factory';
+
+import StreamingFeeExtensionWrapper from '../../wrappers/set-v2-strategies/StreamingFeeExtensionWrapper';
+import Assertions from '../../assertions';
+
+/**
+ * @title  StreamingFeeExtensionAPI
+ * @author Set Protocol
+ *
+ * The StreamingFeeExtensionAPI exposes methods to set issuance and redemption fees for SetTokens using
+ * the DelegatedManager system. The API also provides some helper methods to generate bytecode data packets
+ * that encode module and extension initialization method calls.
+ */
+export default class StreamingFeeExtensionAPI {
+  private streamingFeeExtensionWrapper: StreamingFeeExtensionWrapper;
+  private assert: Assertions;
+
+  public constructor(
+    provider: Provider,
+    streamingFeeExtensionAddress: Address,
+    assertions?: Assertions) {
+    this.streamingFeeExtensionWrapper = new StreamingFeeExtensionWrapper(provider, streamingFeeExtensionAddress);
+    this.assert = assertions || new Assertions();
+  }
+
+  /**
+   * Accrues fees from streaming fee module. Gets resulting balance after fee accrual, calculates fees for
+   * owner and methodologist, and sends to owner fee recipient and methodologist respectively. (Anyone can call
+   * this method.)
+   *
+   * @param setTokenAddress      Instance of deployed SetToken to accrue & distribute streaming fees for
+   *
+   * @return                     Initialization bytecode
+   */
+  public async accrueFeesAndDistribute(setTokenAddress: Address): Promise<ContractTransaction>  {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+
+    return await this.streamingFeeExtensionWrapper.accrueFeesAndDistribute(setTokenAddress);
+  }
+
+  /**
+   * Generates StreamingFeeExtension initialize call bytecode to be passed as an element in the `initializeBytecode`
+   * array for the DelegatedManagerFactory's `initializeAsync` method.
+   *
+   * @param delegatedManagerAddress      Instance of DelegatedManager to initialize the StreamingFeeExtension for
+   *
+   * @return                             Initialization bytecode
+   */
+  public getStreamingFeeExtensionInitializationBytecode(
+    delegatedManagerAddress: Address
+  ): BytesLike {
+    this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
+
+    const extensionInterface = new EthersUtils.Interface(StreamingFeeSplitExtension__factory.abi);
+    return extensionInterface.encodeFunctionData('initialize', [ delegatedManagerAddress ]);
+  }
+
+  /**
+   * Generates StreamingFeeModule initialize call bytecode to be passed as an element in the  `initializeBytecode`
+   * array for the `initializeAsync` method.
+   *
+   * FeeSettings is an object with the properties:
+   * ```
+   * {
+   *   feeRecipient;                    Address to accrue fees to. (Should be the DelegatedManager contract)
+   *   maxStreamingFeePercentage;       Max streaming fee manager commits to using (1% = 1e16, 100% = 1e18)
+   *   streamingFeePercentage;          Percent of Set accruing to manager annually (1% = 1e16, 100% = 1e18)
+   *   lastStreamingFeeTimestamp;       Timestamp last streaming fee was accrued (Should be 0 on init)
+   * }
+   * ```
+   * @param setTokenAddress             Address of deployed SetToken to initialize the StreamingFeeModule for
+   * @param feeSettings                 % of fees in precise units (10^16 = 1%) sent to owner, rest to methodologist
+   *
+   * @return                            Initialization bytecode
+   */
+  public getStreamingFeeModuleInitializationBytecode(
+    setTokenAddress: Address,
+    feeSettings: StreamingFeeState
+  ): BytesLike {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+    this.assert.schema.isValidAddress('feeSettings.feeRecipient', feeSettings.feeRecipient);
+    this.assert.schema.isValidNumber('feeSettings.maxStreamingFeePercentage', feeSettings.maxStreamingFeePercentage);
+    this.assert.schema.isValidNumber('feeSettings.streamingFeePercentage', feeSettings.streamingFeePercentage);
+    this.assert.schema.isValidNumber('feeSettings.lastStreamingFeeTimestamp', feeSettings.lastStreamingFeeTimestamp);
+
+    const moduleInterface = new EthersUtils.Interface(StreamingFeeModule__factory.abi);
+    return moduleInterface.encodeFunctionData('initialize', [ setTokenAddress, feeSettings ]);
+  }
+}

--- a/src/api/extensions/StreamingFeeExtensionAPI.ts
+++ b/src/api/extensions/StreamingFeeExtensionAPI.ts
@@ -54,7 +54,7 @@ export default class StreamingFeeExtensionAPI {
    * @param callerAddress        Address of caller (optional)
    * @param txOpts               Overrides for transaction (optional)
    *
-   * @return                     Initialization bytecode
+   * @return                     ContractTransaction
    */
   public async accrueFeesAndDistributeAsync(
     setTokenAddress: Address,

--- a/src/api/extensions/StreamingFeeExtensionAPI.ts
+++ b/src/api/extensions/StreamingFeeExtensionAPI.ts
@@ -20,9 +20,7 @@ import { ContractTransaction, BytesLike, utils as EthersUtils } from 'ethers';
 import { Provider } from '@ethersproject/providers';
 import { Address, StreamingFeeState } from '@setprotocol/set-protocol-v2/utils/types';
 import { StreamingFeeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/StreamingFeeModule__factory';
-
-// @ts-ignore
-import { StreamingFeeSplitExtension__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/StreamingFeeSplitExtension__factory';
+import { StreamingFeeSplitExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/StreamingFeeSplitExtension__factory';
 
 import StreamingFeeExtensionWrapper from '../../wrappers/set-v2-strategies/StreamingFeeExtensionWrapper';
 import Assertions from '../../assertions';

--- a/src/api/extensions/TradeExtensionAPI.ts
+++ b/src/api/extensions/TradeExtensionAPI.ts
@@ -16,7 +16,7 @@
 
 'use strict';
 
-import { BigNumberish, BytesLike, utils as EthersUtils } from 'ethers';
+import { ContractTransaction, BigNumberish, BytesLike, utils as EthersUtils } from 'ethers';
 import { Provider } from '@ethersproject/providers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
@@ -72,7 +72,7 @@ export default class TradeExtensionAPI {
     data: BytesLike,
     callerAddress: Address = undefined,
     txOpts: TransactionOverrides = {}
-  ) {
+  ): Promise<ContractTransaction> {
     this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
     this.assert.schema.isValidString('exchangeName', exchangeName);
     this.assert.schema.isValidAddress('sendToken', sendToken);

--- a/src/api/extensions/TradeExtensionAPI.ts
+++ b/src/api/extensions/TradeExtensionAPI.ts
@@ -21,8 +21,6 @@ import { Provider } from '@ethersproject/providers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
 import { TradeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/TradeModule__factory';
-
-// @ts-ignore
 import { TradeExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/TradeExtension__factory';
 
 import TradeExtensionWrapper from '../../wrappers/set-v2-strategies/TradeExtensionWrapper';

--- a/src/api/extensions/TradeExtensionAPI.ts
+++ b/src/api/extensions/TradeExtensionAPI.ts
@@ -1,0 +1,131 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { BigNumberish, BytesLike, utils as EthersUtils } from 'ethers';
+import { Provider } from '@ethersproject/providers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { TradeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/TradeModule__factory';
+
+// @ts-ignore
+import { TradeExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/TradeExtension__factory';
+
+import TradeExtensionWrapper from '../../wrappers/set-v2-strategies/TradeExtensionWrapper';
+import Assertions from '../../assertions';
+
+/**
+ * @title  TradeExtensionAPI
+ * @author Set Protocol
+ *
+ * The TradeExtensionAPI exposes methods to trade SetToken components using the TradeModule for SetTokens using
+ * the DelegatedManager system. The API also provides some helper methods to generate bytecode data packets
+ * that encode module and extension initialization method calls.
+ */
+export default class TradeExtensionAPI {
+  private tradeExtensionWrapper: TradeExtensionWrapper;
+  private assert: Assertions;
+
+  public constructor(
+    provider: Provider,
+    TradeExtensionAddress: Address,
+    assertions?: Assertions) {
+    this.tradeExtensionWrapper = new TradeExtensionWrapper(provider, TradeExtensionAddress);
+    this.assert = assertions || new Assertions();
+  }
+
+  /**
+   * Executes a trade on a supported DEX. Must be called an address authorized for the `operator` role
+   * on the TradeExtension
+   *
+   * NOTE: Although the SetToken units are passed in for the send and receive quantities, the total quantity
+   * sent and received is the quantity of SetToken units multiplied by the SetToken totalSupply.
+   *
+   * @param setTokenAddress      Address of the deployed SetToken to trade on behalf of
+   * @param exchangeName         Human readable name of the exchange in the integrations registry
+   * @param sendToken            Address of the token to be sent to the exchange
+   * @param sendQuantity         Units of token in SetToken sent to the exchange
+   * @param receiveToken         Address of the token that will be received from the exchange
+   * @param minReceiveQuantity   Min units of token in SetToken to be received from the exchange
+   * @param data                 Arbitrary bytes to be used to construct trade call data
+   * @param callerAddress        Address of caller (optional)
+   * @param txOpts               Overrides for transaction (optional)
+   */
+  public async tradeWithOperator(
+    setTokenAddress: Address,
+    exchangeName: Address,
+    sendToken: Address,
+    sendQuantity: BigNumberish,
+    receiveToken: Address,
+    minReceiveQuantity: BigNumberish,
+    data: BytesLike,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ) {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+    this.assert.schema.isValidString('exchangeName', exchangeName);
+    this.assert.schema.isValidAddress('sendToken', sendToken);
+    this.assert.schema.isValidNumber('sendQuantity', sendQuantity);
+    this.assert.schema.isValidAddress('receiveToken', receiveToken);
+    this.assert.schema.isValidNumber('minReceiveQuantity', minReceiveQuantity);
+    this.assert.schema.isValidBytes('data', data);
+
+    return await this.tradeExtensionWrapper.tradeWithOperator(
+      setTokenAddress,
+      exchangeName,
+      sendToken,
+      sendQuantity,
+      receiveToken,
+      minReceiveQuantity,
+      data,
+      callerAddress,
+      txOpts
+    );
+  }
+
+  /**
+   * Generates TradeExtension initialize call bytecode to be passed as an element in the  `initializeBytecode`
+   * array for the DelegatedManagerFactory's `initializeAsync` method.
+   *
+   * @param delegatedManagerAddress      Instance of deployed DelegatedManager to initialize the TradeExtension for
+   *
+   * @return                             Initialization bytecode
+   */
+  public getTradeExtensionInitializationBytecode(
+    delegatedManagerAddress: Address
+  ): BytesLike {
+    this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
+
+    const extensionInterface = new EthersUtils.Interface(TradeExtension__factory.abi);
+    return extensionInterface.encodeFunctionData('initialize', [ delegatedManagerAddress ]);
+  }
+
+  /**
+   * Generates TradeModule initialize call bytecode to be passed as an element in the  `initializeBytecode`
+   * array for the `initializeAsync` method.
+   *
+   * @param setTokenAddress              Instance of deployed setToken to initialize the TradeModule for
+   *
+   * @return                             Initialization bytecode
+   */
+  public getTradeModuleInitializationBytecode(setTokenAddress: Address): BytesLike {
+    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+
+    const moduleInterface = new EthersUtils.Interface(TradeModule__factory.abi);
+    return moduleInterface.encodeFunctionData('initialize', [setTokenAddress]);
+  }
+}

--- a/src/api/extensions/TradeExtensionAPI.ts
+++ b/src/api/extensions/TradeExtensionAPI.ts
@@ -63,7 +63,7 @@ export default class TradeExtensionAPI {
    * @param callerAddress        Address of caller (optional)
    * @param txOpts               Overrides for transaction (optional)
    */
-  public async tradeWithOperator(
+  public async tradeWithOperatorAsync(
     setTokenAddress: Address,
     exchangeName: Address,
     sendToken: Address,
@@ -109,7 +109,7 @@ export default class TradeExtensionAPI {
     this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
 
     const extensionInterface = new EthersUtils.Interface(TradeExtension__factory.abi);
-    return extensionInterface.encodeFunctionData('initialize', [ delegatedManagerAddress ]);
+    return extensionInterface.encodeFunctionData('initializeExtension', [ delegatedManagerAddress ]);
   }
 
   /**

--- a/src/api/extensions/TradeExtensionAPI.ts
+++ b/src/api/extensions/TradeExtensionAPI.ts
@@ -20,7 +20,6 @@ import { BigNumberish, BytesLike, utils as EthersUtils } from 'ethers';
 import { Provider } from '@ethersproject/providers';
 import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
-import { TradeModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/TradeModule__factory';
 import { TradeExtension__factory } from '@setprotocol/set-v2-strategies/dist/typechain/factories/TradeExtension__factory';
 
 import TradeExtensionWrapper from '../../wrappers/set-v2-strategies/TradeExtensionWrapper';
@@ -113,17 +112,17 @@ export default class TradeExtensionAPI {
   }
 
   /**
-   * Generates TradeModule initialize call bytecode to be passed as an element in the  `initializeBytecode`
+   * Generates `moduleAndExtensionInitialization` bytecode to be passed as an element in the  `initializeBytecode`
    * array for the `initializeAsync` method.
    *
    * @param setTokenAddress              Instance of deployed setToken to initialize the TradeModule for
    *
    * @return                             Initialization bytecode
    */
-  public getTradeModuleInitializationBytecode(setTokenAddress: Address): BytesLike {
-    this.assert.schema.isValidAddress('setTokenAddress', setTokenAddress);
+  public getTradeModuleAndExtensionInitializationBytecode(delegatedManagerAddress: Address): BytesLike {
+    this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
 
-    const moduleInterface = new EthersUtils.Interface(TradeModule__factory.abi);
-    return moduleInterface.encodeFunctionData('initialize', [setTokenAddress]);
+    const extensionInterface = new EthersUtils.Interface(TradeExtension__factory.abi);
+    return extensionInterface.encodeFunctionData('initializeExtension', [ delegatedManagerAddress ]);
   }
 }

--- a/src/api/extensions/TradeExtensionAPI.ts
+++ b/src/api/extensions/TradeExtensionAPI.ts
@@ -123,6 +123,6 @@ export default class TradeExtensionAPI {
     this.assert.schema.isValidAddress('delegatedManagerAddress', delegatedManagerAddress);
 
     const extensionInterface = new EthersUtils.Interface(TradeExtension__factory.abi);
-    return extensionInterface.encodeFunctionData('initializeExtension', [ delegatedManagerAddress ]);
+    return extensionInterface.encodeFunctionData('initializeModuleAndExtension', [ delegatedManagerAddress ]);
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,6 +13,10 @@ import SlippageIssuanceAPI from './SlippageIssuanceAPI';
 import PerpV2LeverageAPI from './PerpV2LeverageAPI';
 import PerpV2LeverageViewerAPI from './PerpV2LeverageViewerAPI';
 import UtilsAPI from './UtilsAPI';
+import IssuanceExtensionAPI from './extensions/IssuanceExtensionAPI';
+import StreamingFeeExtensionAPI from './extensions/StreamingFeeExtensionAPI';
+import TradeExtensionAPI from './extensions/TradeExtensionAPI';
+
 import {
   TradeQuoter,
   CoinGeckoDataService,
@@ -35,6 +39,9 @@ export {
   PerpV2LeverageAPI,
   PerpV2LeverageViewerAPI,
   UtilsAPI,
+  IssuanceExtensionAPI,
+  StreamingFeeExtensionAPI,
+  TradeExtensionAPI,
   TradeQuoter,
   CoinGeckoDataService,
   GasOracleService

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,6 +13,7 @@ import SlippageIssuanceAPI from './SlippageIssuanceAPI';
 import PerpV2LeverageAPI from './PerpV2LeverageAPI';
 import PerpV2LeverageViewerAPI from './PerpV2LeverageViewerAPI';
 import UtilsAPI from './UtilsAPI';
+import DelegatedManagerFactoryAPI from './DelegatedManagerFactoryAPI';
 import IssuanceExtensionAPI from './extensions/IssuanceExtensionAPI';
 import StreamingFeeExtensionAPI from './extensions/StreamingFeeExtensionAPI';
 import TradeExtensionAPI from './extensions/TradeExtensionAPI';
@@ -39,6 +40,7 @@ export {
   PerpV2LeverageAPI,
   PerpV2LeverageViewerAPI,
   UtilsAPI,
+  DelegatedManagerFactoryAPI,
   IssuanceExtensionAPI,
   StreamingFeeExtensionAPI,
   TradeExtensionAPI,

--- a/src/assertions/SchemaAssertions.ts
+++ b/src/assertions/SchemaAssertions.ts
@@ -72,6 +72,18 @@ export class SchemaAssertions {
   }
 
   /**
+   * Throws if a given input is not a valid list of Byte Strings.
+   *
+   * @param variableName    Variable name being validated. Used for displaying error messages.
+   * @param values          Values being validated.
+   */
+  public isValidBytesList(variableName: string, values: any) {
+    for (const value of values) {
+      this.assertConformsToSchema(variableName, value, schemas.bytesSchema);
+    }
+  }
+
+  /**
    * Throws if a given input is not a number.
    *
    * @param variableName    Variable name being validated. Used for displaying error messages.
@@ -79,6 +91,18 @@ export class SchemaAssertions {
    */
   public isValidNumber(variableName: string, value: any) {
     this.assertConformsToSchema(variableName, value, schemas.numberSchema);
+  }
+
+  /**
+   * Throws if a given input is not a valid list of numbers.
+   *
+   * @param variableName    Variable name being validated. Used for displaying error messages.
+   * @param values          Values being validated.
+   */
+  public isValidNumberList(variableName: string, values: any) {
+    for (const value of values) {
+      this.assertConformsToSchema(variableName, value, schemas.numberSchema);
+    }
   }
 
   /**

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -4,6 +4,12 @@ import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { BigNumber } from 'ethers/lib/ethers';
 import { ZeroExApiUrls } from './utils';
 
+import type {
+  IssuanceExtensionAPI,
+  TradeExtensionAPI,
+  StreamingFeeExtensionAPI
+} from '../api';
+
 export { TransactionReceipt } from 'ethereum-types';
 
 /**
@@ -33,6 +39,9 @@ export interface SetJSConfig {
   perpV2LeverageModuleViewerAddress: Address;
   perpV2BasisTradingModuleAddress: Address;
   perpV2BasisTradingModuleViewerAddress: Address;
+  issuanceExtensionAddress: Address;
+  tradeExtensionAddress: Address;
+  streamingFeeExtensionAddress: Address;
 }
 
 export type SetDetails = {
@@ -149,4 +158,10 @@ export type VAssetDisplayInfo = {
   positionUnit: BigNumber; // 10^18 decimals
   indexPrice: BigNumber; // 10^18 decimals
   currentLeverageRatio: BigNumber; // 10^18 decimals
+};
+
+export type DelegatedManagerSystemExtensions = {
+  issuanceExtension: IssuanceExtensionAPI,
+  tradeExtension: TradeExtensionAPI,
+  streamingFeeExtension: StreamingFeeExtensionAPI
 };

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -34,7 +34,6 @@ export interface SetJSConfig {
   zeroExApiKey?: string;
   zeroExApiUrls?: ZeroExApiUrls;
   debtIssuanceModuleV2Address: Address;
-  issuanceModuleAddress: Address;
   slippageIssuanceModuleAddress: Address;
   perpV2LeverageModuleAddress: Address;
   perpV2LeverageModuleViewerAddress: Address;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -39,6 +39,7 @@ export interface SetJSConfig {
   perpV2LeverageModuleViewerAddress: Address;
   perpV2BasisTradingModuleAddress: Address;
   perpV2BasisTradingModuleViewerAddress: Address;
+  delegatedManagerFactoryAddress: Address;
   issuanceExtensionAddress: Address;
   tradeExtensionAddress: Address;
   streamingFeeExtensionAddress: Address;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -34,6 +34,7 @@ export interface SetJSConfig {
   zeroExApiKey?: string;
   zeroExApiUrls?: ZeroExApiUrls;
   debtIssuanceModuleV2Address: Address;
+  issuanceModuleAddress: Address;
   slippageIssuanceModuleAddress: Address;
   perpV2LeverageModuleAddress: Address;
   perpV2LeverageModuleViewerAddress: Address;

--- a/src/wrappers/set-protocol-v2/ContractWrapper.ts
+++ b/src/wrappers/set-protocol-v2/ContractWrapper.ts
@@ -36,6 +36,7 @@ import {
   PerpV2LeverageModuleViewer,
   PriceOracle,
 } from '@setprotocol/set-protocol-v2/typechain';
+
 import { BasicIssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/BasicIssuanceModule__factory';
 import { DebtIssuanceModule__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/DebtIssuanceModule__factory';
 import { DebtIssuanceModuleV2__factory } from '@setprotocol/set-protocol-v2/dist/typechain/factories/DebtIssuanceModuleV2__factory';

--- a/src/wrappers/set-v2-strategies/ContractWrapper.ts
+++ b/src/wrappers/set-v2-strategies/ContractWrapper.ts
@@ -22,31 +22,23 @@ import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 
 import {
   DelegatedManagerFactory,
-  // TODO: un-ts-ignore missing imports
-  // @ts-ignore
   StreamingFeeSplitExtension,
-  // @ts-ignore
   TradeExtension,
-  // @ts-ignore
   IssuanceExtension
 } from '@setprotocol/set-v2-strategies/typechain';
 
 import {
   DelegatedManagerFactory__factory
 } from '@setprotocol/set-v2-strategies/dist/typechain/factories/DelegatedManagerFactory__factory';
-// TODO: un-ts-ignore missing imports
 import {
   StreamingFeeSplitExtension__factory
-// @ts-ignore
-} from '@setprotocol/set-v2-strategies/dist/typechain/factories/StreamingFeeSplitExtension_factory';
+} from '@setprotocol/set-v2-strategies/dist/typechain/factories/StreamingFeeSplitExtension__factory';
 import {
   TradeExtension__factory,
-  // @ts-ignore
-} from '@setprotocol/set-v2-strategies/dist/typechain/factories/TradeExtension_factory';
+} from '@setprotocol/set-v2-strategies/dist/typechain/factories/TradeExtension__factory';
 import {
   IssuanceExtension__factory
-  // @ts-ignore
-} from '@setprotocol/set-v2-strategies/dist/typechain/factories/IssuanceExtension_factory';
+} from '@setprotocol/set-v2-strategies/dist/typechain/factories/IssuanceExtension__factory';
 
 
 /**

--- a/src/wrappers/set-v2-strategies/ContractWrapper.ts
+++ b/src/wrappers/set-v2-strategies/ContractWrapper.ts
@@ -1,0 +1,175 @@
+/*
+  Copyright 2020 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Provider, JsonRpcProvider } from '@ethersproject/providers';
+import { Contract } from 'ethers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+
+import {
+  DelegatedManagerFactory,
+  // TODO: un-ts-ignore missing imports
+  // @ts-ignore
+  StreamingFeeSplitExtension,
+  // @ts-ignore
+  TradeExtension,
+  // @ts-ignore
+  IssuanceExtension
+} from '@setprotocol/set-v2-strategies/typechain';
+
+import {
+  DelegatedManagerFactory__factory
+} from '@setprotocol/set-v2-strategies/dist/typechain/factories/DelegatedManagerFactory__factory';
+// TODO: un-ts-ignore missing imports
+import {
+  StreamingFeeSplitExtension__factory
+// @ts-ignore
+} from '@setprotocol/set-v2-strategies/dist/typechain/factories/StreamingFeeSplitExtension_factory';
+import {
+  TradeExtension__factory,
+  // @ts-ignore
+} from '@setprotocol/set-v2-strategies/dist/typechain/factories/TradeExtension_factory';
+import {
+  IssuanceExtension__factory
+  // @ts-ignore
+} from '@setprotocol/set-v2-strategies/dist/typechain/factories/IssuanceExtension_factory';
+
+
+/**
+ * @title ContractWrapper
+ * @author Set Protocol
+ *
+ * The Contracts API handles all functions that load contracts for set-v2-strategies
+ *
+ */
+export default class ContractWrapper {
+  private provider: Provider;
+  private cache: { [contractName: string]: Contract };
+
+  public constructor(provider: Provider) {
+    this.provider = provider;
+    this.cache = {};
+  }
+
+  /**
+   * Load DelegatedManagerFactory contract
+   *
+   * @param  DelegatedManagerFactoryAddress  Address of the DelegatedManagerFactory instance
+   * @param  callerAddress                   Address of caller, uses first one on node if none provided.
+   * @return                                 DelegatedManagerFactory contract instance
+   */
+   public async loadDelegatedManagerFactoryAsync(
+    delegatedManagerFactoryAddress: Address,
+    callerAddress?: Address,
+  ): Promise<DelegatedManagerFactory> {
+    const signer = (this.provider as JsonRpcProvider).getSigner(callerAddress);
+    const cacheKey = `DelegatedManagerFactory_${delegatedManagerFactoryAddress}_${await signer.getAddress()}`;
+
+    if (cacheKey in this.cache) {
+      return this.cache[cacheKey] as DelegatedManagerFactory;
+    } else {
+      const delegatedManagerFactoryContract = DelegatedManagerFactory__factory.connect(
+        delegatedManagerFactoryAddress,
+        signer
+      );
+
+      this.cache[cacheKey] = delegatedManagerFactoryContract;
+      return delegatedManagerFactoryContract;
+    }
+  }
+
+  /**
+   * Load StreamingFeeSplitExtension contract
+   *
+   * @param  streamingFeeSplitExtension          Address of the StreamingFeeSplitExtension instance
+   * @param  callerAddress                       Address of caller, uses first one on node if none provided.
+   * @return                                     StreamingFeeSplitExtension contract instance
+   */
+   public async loadStreamingFeeExtensionAsync(
+    streamingFeeSplitExtensionAddress: Address,
+    callerAddress?: Address,
+  ): Promise<StreamingFeeSplitExtension> {
+    const signer = (this.provider as JsonRpcProvider).getSigner(callerAddress);
+    const cacheKey = `StreamingFeeSplitExtension_${streamingFeeSplitExtensionAddress}_${await signer.getAddress()}`;
+
+    if (cacheKey in this.cache) {
+      return this.cache[cacheKey] as StreamingFeeSplitExtension;
+    } else {
+      const streamingFeeSplitExtensionContract = StreamingFeeSplitExtension__factory.connect(
+        streamingFeeSplitExtensionAddress,
+        signer
+      );
+
+      this.cache[cacheKey] = streamingFeeSplitExtensionContract;
+      return streamingFeeSplitExtensionContract;
+    }
+  }
+
+  /**
+   * Load TradeExtension contract
+   *
+   * @param  TradeExtension                      Address of the TradeExtension instance
+   * @param  callerAddress                       Address of caller, uses first one on node if none provided.
+   * @return                                     TradeExtension contract instance
+   */
+   public async loadTradeExtensionAsync(
+    tradeExtensionAddress: Address,
+    callerAddress?: Address,
+  ): Promise<TradeExtension> {
+    const signer = (this.provider as JsonRpcProvider).getSigner(callerAddress);
+    const cacheKey = `tradeExtension_${tradeExtensionAddress}_${await signer.getAddress()}`;
+
+    if (cacheKey in this.cache) {
+      return this.cache[cacheKey] as TradeExtension;
+    } else {
+      const tradeExtensionContract = TradeExtension__factory.connect(
+        tradeExtensionAddress,
+        signer
+      );
+
+      this.cache[cacheKey] = tradeExtensionContract;
+      return tradeExtensionContract;
+    }
+  }
+
+  /**
+   * Load IssuanceExtension contract
+   *
+   * @param  IssuanceExtension                   Address of the IssuanceExtension instance
+   * @param  callerAddress                       Address of caller, uses first one on node if none provided.
+   * @return                                     TradeExtension contract instance
+   */
+   public async loadIssuanceExtensionAsync(
+    issuanceExtensionAddress: Address,
+    callerAddress?: Address,
+  ): Promise<IssuanceExtension> {
+    const signer = (this.provider as JsonRpcProvider).getSigner(callerAddress);
+    const cacheKey = `issuanceExtension_${issuanceExtensionAddress}_${await signer.getAddress()}`;
+
+    if (cacheKey in this.cache) {
+      return this.cache[cacheKey] as IssuanceExtension;
+    } else {
+      const issuanceExtensionContract = IssuanceExtension__factory.connect(
+        issuanceExtensionAddress,
+        signer
+      );
+
+      this.cache[cacheKey] = issuanceExtensionContract;
+      return issuanceExtensionContract;
+    }
+  }
+}

--- a/src/wrappers/set-v2-strategies/IssuanceExtensionWrapper.ts
+++ b/src/wrappers/set-v2-strategies/IssuanceExtensionWrapper.ts
@@ -1,0 +1,64 @@
+/*
+  Copyright 2022 Set Labs Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ContractTransaction } from 'ethers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { Provider } from '@ethersproject/providers';
+import { generateTxOpts } from '../../utils/transactions';
+
+import ContractWrapper from './ContractWrapper';
+
+/**
+ * @title  IssuanceExtensionWrapper
+ * @author Set Protocol
+ *
+ * The IssuanceExtensionWrapper forwards functionality from the IssuanceExtension contract.
+ *
+ */
+export default class IssuanceExtensionWrapper {
+  private provider: Provider;
+  private contracts: ContractWrapper;
+
+  private issuanceExtensionAddress: Address;
+
+  public constructor(provider: Provider, issuanceExtensionAddress: Address) {
+    this.provider = provider;
+    this.contracts = new ContractWrapper(this.provider);
+    this.issuanceExtensionAddress = issuanceExtensionAddress;
+  }
+
+  /**
+   * Distributes issuance and redemption fees calculates fees for. Calculates fees for owner and methodologist
+   * and sends to owner fee recipient and methodologist respectively. (Anyone can call this method.)
+   *
+   * @param setTokenAddress      Instance of deployed SetToken to distribute issuance fees for
+   *
+   * @return                     Initialization bytecode
+   */
+  public async distribute(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const issuanceExtensionInstance = await this.contracts.loadIssuanceExtensionAsync(
+      this.issuanceExtensionAddress,
+      callerAddress
+    );
+
+    return await issuanceExtensionInstance.distribute(setTokenAddress, txOptions);
+  }
+}

--- a/src/wrappers/set-v2-strategies/IssuanceExtensionWrapper.ts
+++ b/src/wrappers/set-v2-strategies/IssuanceExtensionWrapper.ts
@@ -48,7 +48,7 @@ export default class IssuanceExtensionWrapper {
    *
    * @return                     Initialization bytecode
    */
-  public async distribute(
+  public async distributeFees(
     setTokenAddress: Address,
     callerAddress: Address = undefined,
     txOpts: TransactionOverrides = {}
@@ -59,6 +59,6 @@ export default class IssuanceExtensionWrapper {
       callerAddress
     );
 
-    return await issuanceExtensionInstance.distribute(setTokenAddress, txOptions);
+    return await issuanceExtensionInstance.distributeFees(setTokenAddress, txOptions);
   }
 }

--- a/src/wrappers/set-v2-strategies/StreamingFeeExtensionWrapper.ts
+++ b/src/wrappers/set-v2-strategies/StreamingFeeExtensionWrapper.ts
@@ -1,0 +1,65 @@
+/*
+  Copyright 2022 Set Labs Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ContractTransaction } from 'ethers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { Provider } from '@ethersproject/providers';
+import { generateTxOpts } from '../../utils/transactions';
+
+import ContractWrapper from './ContractWrapper';
+
+/**
+ * @title  StreamingFeeExtensionWrapper
+ * @author Set Protocol
+ *
+ * The StreamingFeeExtensionWrapper forwards functionality from the StreamingFeeExtension contract.
+ *
+ */
+export default class StreamingFeeExtensionWrapper {
+  private provider: Provider;
+  private contracts: ContractWrapper;
+
+  private streamingFeeExtensionAddress: Address;
+
+  public constructor(provider: Provider, streamingFeeExtensionAddress: Address) {
+    this.provider = provider;
+    this.contracts = new ContractWrapper(this.provider);
+    this.streamingFeeExtensionAddress = streamingFeeExtensionAddress;
+  }
+
+  /**
+   * Accrues fees from streaming fee module. Gets resulting balance after fee accrual, calculates fees for
+   * owner and methodologist, and sends to owner fee recipient and methodologist respectively. (Anyone can call
+   * this method.)
+   *
+   * @param setTokenAddress      Instance of deployed SetToken to accrue & distribute streaming fees for
+   *
+   * @return                     Initialization bytecode
+   */
+  public async accrueFeesAndDistribute(
+    setTokenAddress: Address,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const streamingFeeExtensionInstance = await this.contracts.loadStreamingFeeExtensionAsync(
+      this.streamingFeeExtensionAddress,
+      callerAddress
+    );
+
+    return await streamingFeeExtensionInstance.accrueFeesAndDistribute(setTokenAddress, txOptions);
+  }
+}

--- a/src/wrappers/set-v2-strategies/TradeExtensionWrapper.ts
+++ b/src/wrappers/set-v2-strategies/TradeExtensionWrapper.ts
@@ -1,0 +1,89 @@
+/*
+  Copyright 2022 Set Labs Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { BigNumberish, BytesLike, ContractTransaction } from 'ethers';
+import { TransactionOverrides } from '@setprotocol/set-protocol-v2/dist/typechain';
+import { Provider } from '@ethersproject/providers';
+import { generateTxOpts } from '../../utils/transactions';
+
+import ContractWrapper from './ContractWrapper';
+
+/**
+ * @title  TradeExtensionWrapper
+ * @author Set Protocol
+ *
+ * The TradeExtensionWrapper forwards functionality from the TradeExtension contract.
+ *
+ */
+export default class TradeExtensionWrapper {
+  private provider: Provider;
+  private contracts: ContractWrapper;
+
+  private tradeExtensionAddress: Address;
+
+  public constructor(provider: Provider, tradeExtensionAddress: Address) {
+    this.provider = provider;
+    this.contracts = new ContractWrapper(this.provider);
+    this.tradeExtensionAddress = tradeExtensionAddress;
+  }
+
+  /**
+   * Executes a trade on a supported DEX. Must be called an address authorized for the `operator` role
+   * on the TradeExtension
+   *
+   * NOTE: Although the SetToken units are passed in for the send and receive quantities, the total quantity
+   * sent and received is the quantity of SetToken units multiplied by the SetToken totalSupply.
+   *
+   * @param setTokenAddress      Address of the deployed SetToken to trade on behalf of
+   * @param exchangeName         Human readable name of the exchange in the integrations registry
+   * @param sendToken            Address of the token to be sent to the exchange
+   * @param sendQuantity         Units of token in SetToken sent to the exchange
+   * @param receiveToken         Address of the token that will be received from the exchange
+   * @param minReceiveQuantity   Min units of token in SetToken to be received from the exchange
+   * @param data                 Arbitrary bytes to be used to construct trade call data
+   * @param callerAddress        Address of caller (optional)
+   * @param txOptions            Overrides for transaction (optional)
+   */
+  public async tradeWithOperator(
+    setTokenAddress: Address,
+    exchangeName: Address,
+    sendToken: Address,
+    sendQuantity: BigNumberish,
+    receiveToken: Address,
+    minReceiveQuantity: BigNumberish,
+    data: BytesLike,
+    callerAddress: Address = undefined,
+    txOpts: TransactionOverrides = {}
+  ): Promise<ContractTransaction> {
+    const txOptions = await generateTxOpts(txOpts);
+    const tradeExtensionInstance = await this.contracts.loadTradeExtensionAsync(
+      this.tradeExtensionAddress,
+      callerAddress
+    );
+
+    return await tradeExtensionInstance.tradeWithOperator(
+      setTokenAddress,
+      exchangeName,
+      sendToken,
+      sendQuantity,
+      receiveToken,
+      minReceiveQuantity,
+      data,
+      callerAddress,
+      txOptions
+    );
+  }
+}

--- a/src/wrappers/set-v2-strategies/TradeExtensionWrapper.ts
+++ b/src/wrappers/set-v2-strategies/TradeExtensionWrapper.ts
@@ -74,7 +74,7 @@ export default class TradeExtensionWrapper {
       callerAddress
     );
 
-    return await tradeExtensionInstance.tradeWithOperator(
+    return await tradeExtensionInstance.trade(
       setTokenAddress,
       exchangeName,
       sendToken,
@@ -82,7 +82,6 @@ export default class TradeExtensionWrapper {
       receiveToken,
       minReceiveQuantity,
       data,
-      callerAddress,
       txOptions
     );
   }

--- a/test/api/DelegatedManagerFactoryAPI.spec.ts
+++ b/test/api/DelegatedManagerFactoryAPI.spec.ts
@@ -1,0 +1,207 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers } from 'ethers';
+import { BigNumber, ContractTransaction } from 'ethers/lib/ethers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+
+import DelegateManagerFactoryAPI from '@src/api/DelegateManagerFactoryAPI';
+import PerpV2LeverageModuleWrapper from '@src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper';
+import { expect } from '../utils/chai';
+
+const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
+
+jest.mock('@src/wrappers/set-protocol-v2/PerpV2LeverageModuleWrapper');
+
+describe('DelegateManagerFactoryAPI', () => {
+  let perpV2LeverageModuleAddress: Address;
+  let setTokenAddress: Address;
+  let owner: Address;
+
+  let perpV2LeverageAPI: DelegateManagerFactoryAPI;
+  let perpV2LeverageModuleWrapper: PerpV2LeverageModuleWrapper;
+
+  beforeEach(async () => {
+    [
+      owner,
+      perpV2LeverageModuleAddress,
+      setTokenAddress,
+    ] = await provider.listAccounts();
+
+    perpV2LeverageAPI = new DelegateManagerFactoryAPI(provider, perpV2LeverageModuleAddress);
+    perpV2LeverageModuleWrapper = (PerpV2LeverageModuleWrapper as any).mock.instances[0];
+  });
+
+  afterEach(() => {
+    (PerpV2LeverageModuleWrapper as any).mockClear();
+  });
+
+  describe('#initializeAsync', () => {
+    let subjectSetTokenAddress: Address;
+    let subjectCallerAddress: Address;
+
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      subjectSetTokenAddress = setTokenAddress;
+      subjectCallerAddress = owner;
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return perpV2LeverageAPI.initializeAsync(
+        subjectSetTokenAddress,
+        subjectCallerAddress,
+        subjectTransactionOptions,
+      );
+    }
+
+    it('should call initialize on the PerpV2LeverageModuleWrapper', async () => {
+      await subject();
+
+      expect(perpV2LeverageModuleWrapper.initialize).to.have.beenCalledWith(
+        subjectSetTokenAddress,
+        subjectCallerAddress,
+        subjectTransactionOptions,
+      );
+    });
+  });
+
+  describe('#getCollateralTokenAsync', () => {
+    let nullCallerAddress: Address;
+
+    beforeEach(async () => {
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
+    });
+
+    async function subject(): Promise<string> {
+      return await perpV2LeverageAPI.getCollateralTokenAsync(
+        nullCallerAddress,
+      );
+    }
+
+    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+      await subject();
+
+      expect(perpV2LeverageModuleWrapper.collateralToken).to.have.beenCalledWith(nullCallerAddress);
+    });
+  });
+
+  describe('#getPositionNotionalInfoAsync', () => {
+    let subjectTokenAddress: Address;
+    let nullCallerAddress: Address;
+
+    beforeEach(async () => {
+      subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      return await perpV2LeverageAPI.getPositionNotionalInfoAsync(
+        subjectTokenAddress,
+        nullCallerAddress,
+      );
+    }
+
+    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+      await subject();
+
+      expect(perpV2LeverageModuleWrapper.getPositionNotionalInfo).to.have.beenCalledWith(
+        subjectTokenAddress,
+        nullCallerAddress,
+      );
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getPositionUnitInfoAsync', () => {
+    let subjectTokenAddress: Address;
+    let nullCallerAddress: Address;
+
+    beforeEach(async () => {
+      subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
+    });
+
+    async function subject(): Promise<(Address|BigNumber)[][]> {
+      return await perpV2LeverageAPI.getPositionUnitInfoAsync(
+        subjectTokenAddress,
+        nullCallerAddress,
+      );
+    }
+
+    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+      await subject();
+
+      expect(perpV2LeverageModuleWrapper.getPositionUnitInfo).to.have.beenCalledWith(
+        subjectTokenAddress,
+        nullCallerAddress,
+      );
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getAccountInfoAsync', () => {
+    let subjectTokenAddress: Address;
+    let nullCallerAddress: Address;
+
+    beforeEach(async () => {
+      subjectTokenAddress = '0xEC0815AA9B462ed4fC84B5dFc43Fd2a10a54B569';
+      nullCallerAddress = '0x0000000000000000000000000000000000000000';
+    });
+
+    async function subject(): Promise<BigNumber[]> {
+      return await perpV2LeverageAPI.getAccountInfoAsync(
+        subjectTokenAddress,
+        nullCallerAddress,
+      );
+    }
+
+    it('should call the PerpV2LeverageModuleWrapper with correct params', async () => {
+      await subject();
+
+      expect(perpV2LeverageModuleWrapper.getAccountInfo).to.have.beenCalledWith(subjectTokenAddress, nullCallerAddress);
+    });
+
+    describe('when the SetToken address is invalid', () => {
+      beforeEach(async () => {
+        subjectTokenAddress = '0xInvalidAddress';
+      });
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+});

--- a/test/api/extensions/IssuanceExtensionAPI.spec.ts
+++ b/test/api/extensions/IssuanceExtensionAPI.spec.ts
@@ -1,0 +1,211 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers, BytesLike } from 'ethers';
+import { BigNumber, ContractTransaction } from 'ethers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ether } from '@setprotocol/set-protocol-v2/dist/utils/common';
+
+import IssuanceExtensionAPI from '@src/api/extensions/IssuanceExtensionAPI';
+import IssuanceExtensionWrapper from '@src/wrappers/set-v2-strategies/IssuanceExtensionWrapper';
+import { expect } from '../../utils/chai';
+
+const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
+
+jest.mock('@src/wrappers/set-v2-strategies/IssuanceExtensionWrapper');
+
+describe('IssuanceExtensionAPI', () => {
+  let owner: Address;
+  let setToken: Address;
+  let issuanceExtension: Address;
+  let delegatedManager: Address;
+  let feeRecipient: Address;
+  let managerIssueHook: Address;
+
+  let issuanceExtensionAPI: IssuanceExtensionAPI;
+  let issuanceExtensionWrapper: IssuanceExtensionWrapper;
+
+  beforeEach(async () => {
+    [
+      owner,
+      setToken,
+      issuanceExtension,
+      delegatedManager,
+      feeRecipient,
+      managerIssueHook,
+    ] = await provider.listAccounts();
+
+    issuanceExtensionAPI = new IssuanceExtensionAPI(provider, issuanceExtension);
+    issuanceExtensionWrapper = (IssuanceExtensionWrapper as any).mock.instances[0];
+  });
+
+  afterEach(() => {
+    (IssuanceExtensionWrapper as any).mockClear();
+  });
+
+  describe('#distributeFeesAsync', () => {
+    let subjectSetToken: Address;
+    let subjectCallerAddress: Address;
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      subjectSetToken = setToken;
+      subjectCallerAddress = owner;
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return issuanceExtensionAPI.distributeFeesAsync(
+        subjectSetToken,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    }
+
+    it('should call `distribute` on the IssuanceExtensionWrapper', async () => {
+      await subject();
+
+      expect(issuanceExtensionWrapper.distributeFees).to.have.beenCalledWith(
+        subjectSetToken,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    });
+
+    describe('when a setToken is not a valid address', () => {
+      beforeEach(() => subjectSetToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getIssuanceExtensionInitializationBytecode', () => {
+    let subjectDelegatedManager: Address;
+
+    beforeEach(async () => {
+      subjectDelegatedManager = delegatedManager;
+    });
+
+    async function subject(): Promise<BytesLike> {
+      return issuanceExtensionAPI.getIssuanceExtensionInitializationBytecode(
+        subjectDelegatedManager
+      );
+    }
+
+    it('should generate the expected bytecode', async () => {
+      const expectedBytecode = '0xde2236bd000000000000000000000000e834ec434daba538cd1b9fe1582052b880bd7e63';
+      expect(await subject()).eq(expectedBytecode);
+    });
+
+    describe('when delegatedManager is not a valid address', () => {
+      beforeEach(() => subjectDelegatedManager = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getIssuanceModuleInitializationBytecode', () => {
+    let subjectSetToken: Address;
+    let subjectMaxManagerFee: BigNumber;
+    let subjectManagerIssueFee: BigNumber;
+    let subjectManagerRedeemFee: BigNumber;
+    let subjectFeeRecipient: Address;
+    let subjectManagerIssuanceHook: Address;
+
+    beforeEach(async () => {
+      subjectSetToken = setToken;
+      subjectMaxManagerFee = ether(.5);
+      subjectManagerIssueFee = ether(.05);
+      subjectManagerRedeemFee =  ether(.04);
+      subjectFeeRecipient = feeRecipient;
+      subjectManagerIssuanceHook = managerIssueHook;
+    });
+
+    async function subject(): Promise<BytesLike> {
+      return issuanceExtensionAPI.getIssuanceModuleInitializationBytecode(
+        subjectSetToken,
+        subjectMaxManagerFee,
+        subjectManagerIssueFee,
+        subjectManagerRedeemFee,
+        subjectFeeRecipient,
+        subjectManagerIssuanceHook
+      );
+    }
+
+    it('should generate the expected bytecode', async () => {
+      const expectedBytecode =
+        '0xbf9fe1380000000000000000000000006ecbe1db9ef729cbe972c83fb886247691fb6beb000000000000000' +
+        '00000000000000000000000000000000006f05b59d3b200000000000000000000000000000000000000000000' +
+        '0000000000b1a2bc2ec50000000000000000000000000000000000000000000000000000008e1bc9bf0400000' +
+        '0000000000000000000000078dc5d2d739606d31509c31d654056a45185ecb6000000000000000000000000a8' +
+        'dda8d7f5310e4a9e24f8eba77e091ac264f872';
+
+      expect(await subject()).eq(expectedBytecode);
+    });
+
+    describe('when setToken is not a valid address', () => {
+      beforeEach(() => subjectSetToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when maxManagerFee is not a valid number', () => {
+      beforeEach(() => subjectMaxManagerFee = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when managerIssueFee is not a valid number', () => {
+      beforeEach(() => subjectManagerIssueFee = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when managerRedeemFee is not a valid number', () => {
+      beforeEach(() => subjectManagerRedeemFee = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when feeRecipient is not a valid address', () => {
+      beforeEach(() => subjectFeeRecipient = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when managerIssuanceHook is not a valid address', () => {
+      beforeEach(() => subjectManagerIssuanceHook = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+});

--- a/test/api/extensions/IssuanceExtensionAPI.spec.ts
+++ b/test/api/extensions/IssuanceExtensionAPI.spec.ts
@@ -121,8 +121,8 @@ describe('IssuanceExtensionAPI', () => {
     });
   });
 
-  describe('#getIssuanceModuleInitializationBytecode', () => {
-    let subjectSetToken: Address;
+  describe('#getIssuanceModuleAndExtensionInitializationBytecode', () => {
+    let subjectDelegatedManager: Address;
     let subjectMaxManagerFee: BigNumber;
     let subjectManagerIssueFee: BigNumber;
     let subjectManagerRedeemFee: BigNumber;
@@ -130,7 +130,7 @@ describe('IssuanceExtensionAPI', () => {
     let subjectManagerIssuanceHook: Address;
 
     beforeEach(async () => {
-      subjectSetToken = setToken;
+      subjectDelegatedManager = delegatedManager;
       subjectMaxManagerFee = ether(.5);
       subjectManagerIssueFee = ether(.05);
       subjectManagerRedeemFee =  ether(.04);
@@ -139,8 +139,8 @@ describe('IssuanceExtensionAPI', () => {
     });
 
     async function subject(): Promise<BytesLike> {
-      return issuanceExtensionAPI.getIssuanceModuleInitializationBytecode(
-        subjectSetToken,
+      return issuanceExtensionAPI.getIssuanceModuleAndExtensionInitializationBytecode(
+        subjectDelegatedManager,
         subjectMaxManagerFee,
         subjectManagerIssueFee,
         subjectManagerRedeemFee,
@@ -151,7 +151,7 @@ describe('IssuanceExtensionAPI', () => {
 
     it('should generate the expected bytecode', async () => {
       const expectedBytecode =
-        '0xbf9fe1380000000000000000000000006ecbe1db9ef729cbe972c83fb886247691fb6beb000000000000000' +
+        '0xb738ad91000000000000000000000000e834ec434daba538cd1b9fe1582052b880bd7e63000000000000000' +
         '00000000000000000000000000000000006f05b59d3b200000000000000000000000000000000000000000000' +
         '0000000000b1a2bc2ec50000000000000000000000000000000000000000000000000000008e1bc9bf0400000' +
         '0000000000000000000000078dc5d2d739606d31509c31d654056a45185ecb6000000000000000000000000a8' +
@@ -161,7 +161,7 @@ describe('IssuanceExtensionAPI', () => {
     });
 
     describe('when setToken is not a valid address', () => {
-      beforeEach(() => subjectSetToken = '0xinvalid');
+      beforeEach(() => subjectDelegatedManager = '0xinvalid');
 
       it('should throw with invalid params', async () => {
         await expect(subject()).to.be.rejectedWith('Validation error');

--- a/test/api/extensions/StreamingFeeExtensionAPI.spec.ts
+++ b/test/api/extensions/StreamingFeeExtensionAPI.spec.ts
@@ -54,7 +54,7 @@ describe('StreamingFeeExtensionAPI', () => {
     (StreamingFeeExtensionWrapper as any).mockClear();
   });
 
-  describe('#accrueFeesAndDistribute(ISetToken _setToken)', () => {
+  describe('#accrueFeesAndDistributeAsync', () => {
     let subjectSetToken: Address;
     let subjectCallerAddress: Address;
     let subjectTransactionOptions: any;
@@ -66,7 +66,7 @@ describe('StreamingFeeExtensionAPI', () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return streamingFeeExtensionAPI.accrueFeesAndDistribute(
+      return streamingFeeExtensionAPI.accrueFeesAndDistributeAsync(
         subjectSetToken,
         subjectCallerAddress,
         subjectTransactionOptions

--- a/test/api/extensions/StreamingFeeExtensionAPI.spec.ts
+++ b/test/api/extensions/StreamingFeeExtensionAPI.spec.ts
@@ -119,12 +119,12 @@ describe('StreamingFeeExtensionAPI', () => {
     });
   });
 
-  describe('#getStreamingFeeModuleInitializationBytecode', () => {
-    let subjectSetToken: Address;
+  describe('#getStreamingFeeModuleAndExtensionInitializationBytecode', () => {
+    let subjectDelegatedManager: Address;
     let subjectFeeSettings: StreamingFeeState;
 
     beforeEach(async () => {
-      subjectSetToken = setToken;
+      subjectDelegatedManager = delegatedManager;
       subjectFeeSettings = {
         feeRecipient,
         maxStreamingFeePercentage: ether(.1),
@@ -134,15 +134,15 @@ describe('StreamingFeeExtensionAPI', () => {
     });
 
     async function subject(): Promise<BytesLike> {
-      return streamingFeeExtensionAPI.getStreamingFeeModuleInitializationBytecode(
-        subjectSetToken,
+      return streamingFeeExtensionAPI.getStreamingFeeModuleAndExtensionInitializationBytecode(
+        subjectDelegatedManager,
         subjectFeeSettings
       );
     }
 
     it('should generate the expected bytecode', async () => {
       const expectedBytecode =
-        '0xeb78e5ee0000000000000000000000006ecbe1db9ef729cbe972c83fb886247691fb6beb000000000000000' +
+        '0x51146818000000000000000000000000e36ea790bc9d7ab70c55260c66d52b1eca985f84000000000000000' +
         '00000000078dc5d2d739606d31509c31d654056a45185ecb60000000000000000000000000000000000000000' +
         '00000000016345785d8a0000000000000000000000000000000000000000000000000000002386f26fc100000' +
         '000000000000000000000000000000000000000000000000000000000000000';
@@ -151,7 +151,7 @@ describe('StreamingFeeExtensionAPI', () => {
     });
 
     describe('when setToken is not a valid address', () => {
-      beforeEach(() => subjectSetToken = '0xinvalid');
+      beforeEach(() => subjectDelegatedManager = '0xinvalid');
 
       it('should throw with invalid params', async () => {
         await expect(subject()).to.be.rejectedWith('Validation error');

--- a/test/api/extensions/StreamingFeeExtensionAPI.spec.ts
+++ b/test/api/extensions/StreamingFeeExtensionAPI.spec.ts
@@ -1,0 +1,193 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers, BytesLike } from 'ethers';
+import { BigNumber, ContractTransaction } from 'ethers';
+import { Address, StreamingFeeState } from '@setprotocol/set-protocol-v2/utils/types';
+import { ether } from '@setprotocol/set-protocol-v2/dist/utils/common';
+
+import StreamingFeeExtensionAPI from '@src/api/extensions/StreamingFeeExtensionAPI';
+import StreamingFeeExtensionWrapper from '@src/wrappers/set-v2-strategies/StreamingFeeExtensionWrapper';
+import { expect } from '../../utils/chai';
+
+const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
+
+jest.mock('@src/wrappers/set-v2-strategies/StreamingFeeExtensionWrapper');
+
+describe('StreamingFeeExtensionAPI', () => {
+  let owner: Address;
+  let setToken: Address;
+  let streamingFeeExtension: Address;
+  let delegatedManager: Address;
+  let feeRecipient: Address;
+
+  let streamingFeeExtensionAPI: StreamingFeeExtensionAPI;
+  let streamingFeeExtensionWrapper: StreamingFeeExtensionWrapper;
+
+  beforeEach(async () => {
+    [
+      owner,
+      setToken,
+      delegatedManager,
+      streamingFeeExtension,
+      feeRecipient,
+    ] = await provider.listAccounts();
+
+    streamingFeeExtensionAPI = new StreamingFeeExtensionAPI(provider, streamingFeeExtension);
+    streamingFeeExtensionWrapper = (StreamingFeeExtensionWrapper as any).mock.instances[0];
+  });
+
+  afterEach(() => {
+    (StreamingFeeExtensionWrapper as any).mockClear();
+  });
+
+  describe('#accrueFeesAndDistribute(ISetToken _setToken)', () => {
+    let subjectSetToken: Address;
+    let subjectCallerAddress: Address;
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      subjectSetToken = setToken;
+      subjectCallerAddress = owner;
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return streamingFeeExtensionAPI.accrueFeesAndDistribute(
+        subjectSetToken,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    }
+
+    it('should call `distribute` on the StreamingFeeExtensionWrapper', async () => {
+      await subject();
+
+      expect(streamingFeeExtensionWrapper.accrueFeesAndDistribute).to.have.beenCalledWith(
+        subjectSetToken,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    });
+
+    describe('when a setToken is not a valid address', () => {
+      beforeEach(() => subjectSetToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getStreamingFeeExtensionInitializationBytecode', () => {
+    let subjectDelegatedManager: Address;
+
+    beforeEach(async () => {
+      subjectDelegatedManager = delegatedManager;
+    });
+
+    async function subject(): Promise<BytesLike> {
+      return streamingFeeExtensionAPI.getStreamingFeeExtensionInitializationBytecode(
+        subjectDelegatedManager
+      );
+    }
+
+    it('should generate the expected bytecode', async () => {
+      const expectedBytecode = '0xde2236bd000000000000000000000000e36ea790bc9d7ab70c55260c66d52b1eca985f84';
+      expect(await subject()).eq(expectedBytecode);
+    });
+
+    describe('when delegatedManager is not a valid address', () => {
+      beforeEach(() => subjectDelegatedManager = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getStreamingFeeModuleInitializationBytecode', () => {
+    let subjectSetToken: Address;
+    let subjectFeeSettings: StreamingFeeState;
+
+    beforeEach(async () => {
+      subjectSetToken = setToken;
+      subjectFeeSettings = {
+        feeRecipient,
+        maxStreamingFeePercentage: ether(.1),
+        streamingFeePercentage: ether(.01),
+        lastStreamingFeeTimestamp: ether(0),
+      };
+    });
+
+    async function subject(): Promise<BytesLike> {
+      return streamingFeeExtensionAPI.getStreamingFeeModuleInitializationBytecode(
+        subjectSetToken,
+        subjectFeeSettings
+      );
+    }
+
+    it('should generate the expected bytecode', async () => {
+      const expectedBytecode =
+        '0xeb78e5ee0000000000000000000000006ecbe1db9ef729cbe972c83fb886247691fb6beb000000000000000' +
+        '00000000078dc5d2d739606d31509c31d654056a45185ecb60000000000000000000000000000000000000000' +
+        '00000000016345785d8a0000000000000000000000000000000000000000000000000000002386f26fc100000' +
+        '000000000000000000000000000000000000000000000000000000000000000';
+
+      expect(await subject()).eq(expectedBytecode);
+    });
+
+    describe('when setToken is not a valid address', () => {
+      beforeEach(() => subjectSetToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when feeSettings.feeRecipient is not a valid address', () => {
+      beforeEach(() => subjectFeeSettings.feeRecipient = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when feeSettings.maxStreamingFeePercentage is not a valid number', () => {
+      beforeEach(() => subjectFeeSettings.maxStreamingFeePercentage = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when feeSettings.streamingFeePercentage is not a valid number', () => {
+      beforeEach(() => subjectFeeSettings.streamingFeePercentage = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when feeSettings.lastStreamingFeeTimestamp is not a valid number', () => {
+      beforeEach(() => subjectFeeSettings.lastStreamingFeeTimestamp = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+});

--- a/test/api/extensions/TradeExtensionAPI.spec.ts
+++ b/test/api/extensions/TradeExtensionAPI.spec.ts
@@ -1,0 +1,213 @@
+/*
+  Copyright 2022 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ethers, BytesLike } from 'ethers';
+import { BigNumber, ContractTransaction } from 'ethers';
+import { Address } from '@setprotocol/set-protocol-v2/utils/types';
+import { ether } from '@setprotocol/set-protocol-v2/dist/utils/common';
+
+import TradeExtensionAPI from '@src/api/extensions/TradeExtensionAPI';
+import TradeExtensionWrapper from '@src/wrappers/set-v2-strategies/TradeExtensionWrapper';
+import { expect } from '../../utils/chai';
+
+const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
+
+jest.mock('@src/wrappers/set-v2-strategies/TradeExtensionWrapper');
+
+describe('TradeExtensionAPI', () => {
+  let owner: Address;
+  let setToken: Address;
+  let tradeExtension: Address;
+  let delegatedManager: Address;
+  let sendToken: Address;
+  let receiveToken: Address;
+
+  let tradeExtensionAPI: TradeExtensionAPI;
+  let tradeExtensionWrapper: TradeExtensionWrapper;
+
+  beforeEach(async () => {
+    [
+      owner,
+      setToken,
+      delegatedManager,
+      tradeExtension,
+      sendToken,
+      receiveToken,
+    ] = await provider.listAccounts();
+
+    tradeExtensionAPI = new TradeExtensionAPI(provider, tradeExtension);
+    tradeExtensionWrapper = (TradeExtensionWrapper as any).mock.instances[0];
+  });
+
+  afterEach(() => {
+    (TradeExtensionWrapper as any).mockClear();
+  });
+
+  describe('#tradeWithOperatorAsync', () => {
+    let subjectSetToken: Address;
+    let subjectExchangeName: string;
+    let subjectSendToken: Address;
+    let subjectSendQuantity: BigNumber;
+    let subjectReceiveToken: Address;
+    let subjectMinReceiveQuantity: BigNumber;
+    let subjectData: string;
+    let subjectCallerAddress: Address;
+    let subjectTransactionOptions: any;
+
+    beforeEach(async () => {
+      subjectSetToken = setToken;
+      subjectExchangeName = 'UniswapV3';
+      subjectSendToken = sendToken;
+      subjectSendQuantity = ether(1);
+      subjectReceiveToken = receiveToken;
+      subjectMinReceiveQuantity = ether(.5);
+      subjectData = '0x123456789abcdedf';
+      subjectCallerAddress = owner;
+      subjectTransactionOptions = {};
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return tradeExtensionAPI.tradeWithOperatorAsync(
+        subjectSetToken,
+        subjectExchangeName,
+        subjectSendToken,
+        subjectSendQuantity,
+        subjectReceiveToken,
+        subjectMinReceiveQuantity,
+        subjectData,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    }
+
+    it('should call `tradeWithOperator` on the TradeExtensionWrapper', async () => {
+      await subject();
+
+      expect(tradeExtensionWrapper.tradeWithOperator).to.have.beenCalledWith(
+        subjectSetToken,
+        subjectExchangeName,
+        subjectSendToken,
+        subjectSendQuantity,
+        subjectReceiveToken,
+        subjectMinReceiveQuantity,
+        subjectData,
+        subjectCallerAddress,
+        subjectTransactionOptions
+      );
+    });
+
+    describe('when a setToken is not a valid address', () => {
+      beforeEach(() => subjectSetToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when a exchangeName is not a valid string', () => {
+      beforeEach(() => subjectExchangeName = <unknown>5 as string);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when a sendToken is not a valid address', () => {
+      beforeEach(() => subjectSendToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when sendQuantity is not a valid number', () => {
+      beforeEach(() => subjectSendQuantity = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when a receiveToken is not a valid address', () => {
+      beforeEach(() => subjectReceiveToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+
+    describe('when minReceiveQuantity is not a valid number', () => {
+      beforeEach(() => subjectMinReceiveQuantity = <unknown>NaN as BigNumber);
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getTradeExtensionInitializationBytecode', () => {
+    let subjectDelegatedManager: Address;
+
+    beforeEach(async () => {
+      subjectDelegatedManager = delegatedManager;
+    });
+
+    async function subject(): Promise<BytesLike> {
+      return tradeExtensionAPI.getTradeExtensionInitializationBytecode(
+        subjectDelegatedManager
+      );
+    }
+
+    it('should generate the expected bytecode', async () => {
+      const expectedBytecode = '0xde2236bd000000000000000000000000e36ea790bc9d7ab70c55260c66d52b1eca985f84';
+      expect(await subject()).eq(expectedBytecode);
+    });
+
+    describe('when delegatedManager is not a valid address', () => {
+      beforeEach(() => subjectDelegatedManager = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+
+  describe('#getTradeModuleInitializationBytecode', () => {
+    let subjectSetToken: Address;
+
+    beforeEach(async () => {
+      subjectSetToken = setToken;
+    });
+
+    async function subject(): Promise<BytesLike> {
+      return tradeExtensionAPI.getTradeModuleInitializationBytecode(subjectSetToken);
+    }
+
+    it('should generate the expected bytecode', async () => {
+      const expectedBytecode = '0xc4d66de80000000000000000000000006ecbe1db9ef729cbe972c83fb886247691fb6beb';
+
+      expect(await subject()).eq(expectedBytecode);
+    });
+
+    describe('when setToken is not a valid address', () => {
+      beforeEach(() => subjectSetToken = '0xinvalid');
+
+      it('should throw with invalid params', async () => {
+        await expect(subject()).to.be.rejectedWith('Validation error');
+      });
+    });
+  });
+});

--- a/test/api/extensions/TradeExtensionAPI.spec.ts
+++ b/test/api/extensions/TradeExtensionAPI.spec.ts
@@ -185,25 +185,25 @@ describe('TradeExtensionAPI', () => {
     });
   });
 
-  describe('#getTradeModuleInitializationBytecode', () => {
-    let subjectSetToken: Address;
+  describe('#getTradeModuleAndExtensionInitializationBytecode', () => {
+    let subjectDelegatedManager: Address;
 
     beforeEach(async () => {
-      subjectSetToken = setToken;
+      subjectDelegatedManager = delegatedManager;
     });
 
     async function subject(): Promise<BytesLike> {
-      return tradeExtensionAPI.getTradeModuleInitializationBytecode(subjectSetToken);
+      return tradeExtensionAPI.getTradeModuleAndExtensionInitializationBytecode(subjectDelegatedManager);
     }
 
     it('should generate the expected bytecode', async () => {
-      const expectedBytecode = '0xc4d66de80000000000000000000000006ecbe1db9ef729cbe972c83fb886247691fb6beb';
+      const expectedBytecode = '0xde2236bd000000000000000000000000e36ea790bc9d7ab70c55260c66d52b1eca985f84';
 
       expect(await subject()).eq(expectedBytecode);
     });
 
     describe('when setToken is not a valid address', () => {
-      beforeEach(() => subjectSetToken = '0xinvalid');
+      beforeEach(() => subjectDelegatedManager = '0xinvalid');
 
       it('should throw with invalid params', async () => {
         await expect(subject()).to.be.rejectedWith('Validation error');

--- a/test/api/extensions/TradeExtensionAPI.spec.ts
+++ b/test/api/extensions/TradeExtensionAPI.spec.ts
@@ -197,7 +197,7 @@ describe('TradeExtensionAPI', () => {
     }
 
     it('should generate the expected bytecode', async () => {
-      const expectedBytecode = '0xde2236bd000000000000000000000000e36ea790bc9d7ab70c55260c66d52b1eca985f84';
+      const expectedBytecode = '0x9b468312000000000000000000000000e36ea790bc9d7ab70c55260c66d52b1eca985f84';
 
       expect(await subject()).eq(expectedBytecode);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,10 +1040,10 @@
     module-alias "^2.2.2"
     replace-in-file "^6.1.0"
 
-"@setprotocol/set-v2-strategies@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.6.tgz#f9a3a39acbddf376c355275dee323a544e3fe2fb"
-  integrity sha512-4Qwgvf05klsrfWC16rzcppL7BCtldlsRZNLXrwZhnx8iUqqb+CGzbE2kEuSJU0vZG0Q0jTEPF6R+GPGIvk0sxA==
+"@setprotocol/set-v2-strategies@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.7.tgz#dca84f40c31b7118b6ff527f372d7fe2906f53ad"
+  integrity sha512-YfA1obWvj2v/lsNnwrCHf2wRud+mdUZutHJggZyziqMokFi6dsej9StczSt8ftWUsWQqQnnGshVcBAjSL0T1sQ==
   dependencies:
     "@setprotocol/set-protocol-v2" "^0.1.11-hardhat.0"
     "@uniswap/v3-sdk" "^3.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,10 +1040,10 @@
     module-alias "^2.2.2"
     replace-in-file "^6.1.0"
 
-"@setprotocol/set-v2-strategies@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.4.tgz#e71d4a6da3fbb05d64755afe1c1646f0024c78c2"
-  integrity sha512-0TbLst3lBeN9J2fsWJUyTCJq/5TBHZWVVvNZZy6WJtIaAU7eZeXl7RFYuIenERIxrOyKUEdiRbznBlwo9l/6tg==
+"@setprotocol/set-v2-strategies@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.5.tgz#4f9fc0b9f434ca799d541924b6eb77af361415a0"
+  integrity sha512-UfmOG2Khkn9vitAOQYbSzlE3D5pv5ZKm3daEchCvKrY6gEmn6QhGmhhIlrjL7FrKLPCv6ljNLTJwBmtruQGEUQ==
   dependencies:
     "@setprotocol/set-protocol-v2" "^0.1.11-hardhat.0"
     "@uniswap/v3-sdk" "^3.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,31 @@
     module-alias "^2.2.2"
     replace-in-file "^6.1.0"
 
+"@setprotocol/set-protocol-v2@^0.1.11-hardhat.0":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.12.tgz#4ff67d0d2935148908ddada79bc51fda17c97afa"
+  integrity sha512-0zHRCTgASXR4P8ya0lafF4WSjnVsc6N7QMLiOGymVfuoSJDpDD+jGOn57FnVmgeknmt60frxJYMxxn5XQN9lyw==
+  dependencies:
+    "@uniswap/v3-sdk" "^3.5.1"
+    ethers "^5.5.2"
+    fs-extra "^5.0.0"
+    jsbi "^3.2.5"
+    module-alias "^2.2.2"
+    replace-in-file "^6.1.0"
+
+"@setprotocol/set-v2-strategies@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.4.tgz#e71d4a6da3fbb05d64755afe1c1646f0024c78c2"
+  integrity sha512-0TbLst3lBeN9J2fsWJUyTCJq/5TBHZWVVvNZZy6WJtIaAU7eZeXl7RFYuIenERIxrOyKUEdiRbznBlwo9l/6tg==
+  dependencies:
+    "@setprotocol/set-protocol-v2" "^0.1.11-hardhat.0"
+    "@uniswap/v3-sdk" "^3.5.1"
+    ethers "5.5.2"
+    fs-extra "^5.0.0"
+    jsbi "^3.2.5"
+    module-alias "^2.2.2"
+    replace-in-file "^6.1.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,10 +1016,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@setprotocol/set-protocol-v2@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.10.tgz#a8135e3e57cbdb857392bcf3cfe98d23bdc91333"
-  integrity sha512-PoDRg+ZeNk7eATvfqPxe1yMLTFoIgAfGA8oUmC8FTIM7F5Ya6wJCpzoJFaLcbd3lWK9+GUkoh6D1onLCatU5hw==
+"@setprotocol/set-protocol-v2@^0.1.11-hardhat.0":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.12.tgz#4ff67d0d2935148908ddada79bc51fda17c97afa"
+  integrity sha512-0zHRCTgASXR4P8ya0lafF4WSjnVsc6N7QMLiOGymVfuoSJDpDD+jGOn57FnVmgeknmt60frxJYMxxn5XQN9lyw==
   dependencies:
     "@uniswap/v3-sdk" "^3.5.1"
     ethers "^5.5.2"
@@ -1028,10 +1028,10 @@
     module-alias "^2.2.2"
     replace-in-file "^6.1.0"
 
-"@setprotocol/set-protocol-v2@^0.1.11-hardhat.0":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.12.tgz#4ff67d0d2935148908ddada79bc51fda17c97afa"
-  integrity sha512-0zHRCTgASXR4P8ya0lafF4WSjnVsc6N7QMLiOGymVfuoSJDpDD+jGOn57FnVmgeknmt60frxJYMxxn5XQN9lyw==
+"@setprotocol/set-protocol-v2@^0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-protocol-v2/-/set-protocol-v2-0.1.15.tgz#d4c4ce5fe35ba136d045919635ea6abdf95489ba"
+  integrity sha512-XZxHXgGqKSk1SMlSeT7lA14nrfvjQ24xc+D+RpiZ/Qj6OAvuceFJ1rDGH234cTg3j3c7gUdAAe2XZ7hgVUenFA==
   dependencies:
     "@uniswap/v3-sdk" "^3.5.1"
     ethers "^5.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,10 +1040,10 @@
     module-alias "^2.2.2"
     replace-in-file "^6.1.0"
 
-"@setprotocol/set-v2-strategies@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.5.tgz#4f9fc0b9f434ca799d541924b6eb77af361415a0"
-  integrity sha512-UfmOG2Khkn9vitAOQYbSzlE3D5pv5ZKm3daEchCvKrY6gEmn6QhGmhhIlrjL7FrKLPCv6ljNLTJwBmtruQGEUQ==
+"@setprotocol/set-v2-strategies@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@setprotocol/set-v2-strategies/-/set-v2-strategies-0.0.6.tgz#f9a3a39acbddf376c355275dee323a544e3fe2fb"
+  integrity sha512-4Qwgvf05klsrfWC16rzcppL7BCtldlsRZNLXrwZhnx8iUqqb+CGzbE2kEuSJU0vZG0Q0jTEPF6R+GPGIvk0sxA==
   dependencies:
     "@setprotocol/set-protocol-v2" "^0.1.11-hardhat.0"
     "@uniswap/v3-sdk" "^3.5.1"


### PR DESCRIPTION
Adds:
+ DelegatedManagerFactoryAPI
+ IssuanceExtensionAPI
+ TradeExtensionAPI
+ StreamingFeeExtensionAPI

Extensions are available on an `extensions` object exposed by the SetJS instance
```ts
setJS.extensions.tradeExtension.tradeForOperator(....)
```

**TODO**
- [x] Update set-v2-strategies packages to `0.0.7`
- [x] Check that imported ABIs **DO NOT** have hardcoded gas values 
  + is it possible to make set-protocol-v2 a dev-dependency at set-v2-strategies?
- [x] Un-ts-ignore missing imports
- [x] Complete tests