### PR TITLE
Add config options for BasisTradingModule/Viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -130,6 +130,18 @@ class Set {
   public perpV2LeverageViewer: PerpV2LeverageViewerAPI;
 
   /**
+   * Another instance of the PerpV2LeverageAPI class, but for more specialized BasisTradingModule
+   * Sets.
+   */
+  public perpV2BasisTrading: PerpV2LeverageAPI;
+
+  /**
+   * Another instance of the PerpV2LeverageViewerAPI class, but for more specialized BasisTradingModule
+   * Sets.
+   */
+  public perpV2BasisTradingViewer: PerpV2LeverageViewerAPI;
+
+  /**
    * An instance of the BlockchainAPI class. Contains interfaces for
    * interacting with the blockchain
    */
@@ -170,6 +182,9 @@ class Set {
     this.slippageIssuance = new SlippageIssuanceAPI(ethersProvider, config.slippageIssuanceModuleAddress);
     this.perpV2Leverage = new PerpV2LeverageAPI(ethersProvider, config.perpV2LeverageModuleAddress);
     this.perpV2LeverageViewer = new PerpV2LeverageViewerAPI(ethersProvider, config.perpV2LeverageModuleViewerAddress);
+    this.perpV2BasisTrading = new PerpV2LeverageAPI(ethersProvider, config.perpV2BasisTradingModuleAddress);
+    this.perpV2BasisTradingViewer = new PerpV2LeverageViewerAPI(ethersProvider,
+                                                                config.perpV2BasisTradingModuleViewerAddress);
     this.blockchain = new BlockchainAPI(ethersProvider, assertions);
     this.utils = new UtilsAPI(ethersProvider, config.zeroExApiKey, config.zeroExApiUrls);
   }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -31,6 +31,8 @@ export interface SetJSConfig {
   slippageIssuanceModuleAddress: Address;
   perpV2LeverageModuleAddress: Address;
   perpV2LeverageModuleViewerAddress: Address;
+  perpV2BasisTradingModuleAddress: Address;
+  perpV2BasisTradingModuleViewerAddress: Address;
 }
 
 export type SetDetails = {


### PR DESCRIPTION
These will use the same interfaces for the existing PerpV2LeverageModule/Viewer API classes.

For Basic data fetching related to vAsset positions/collateral token data and balances.