### PR TITLE
Update TradeQuoter to use `ZeroExApiAdapterV5` [SIM-230]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "set.js",
-    "version": "0.5.3",
+    "version": "0.5.4-zeroex.0",
     "description": "A javascript library for interacting with the Set Protocol v2",
     "keywords": [
         "set.js",

--- a/src/api/utils/tradeQuoter.ts
+++ b/src/api/utils/tradeQuoter.ts
@@ -57,7 +57,7 @@ export class TradeQuoter {
   private feePercentage: number = 0;
   private isFirmQuote: boolean = true;
   private slippagePercentage: number = 2;
-  private excludedSources: string[] = ['Kyber', 'Eth2Dai', 'Mesh', 'RFQT'];
+  private excludedSources: string[] = ['Kyber', 'Eth2Dai', 'Mesh'];
   private zeroExApiKey: string;
   private zeroExApiUrls: ZeroExApiUrls;
 

--- a/src/api/utils/tradeQuoter.ts
+++ b/src/api/utils/tradeQuoter.ts
@@ -38,7 +38,7 @@ import { Address } from '@setprotocol/set-protocol-v2/utils/types';
 import { GasOracleService } from './gasOracle';
 import { ZeroExTradeQuoter } from './zeroex';
 
-export const ZERO_EX_ADAPTER_NAME = 'ZeroExApiAdapterV4';
+export const ZERO_EX_ADAPTER_NAME = 'ZeroExApiAdapterV5';
 
 const SCALE = BigNumber.from(10).pow(18);
 

--- a/test/fixtures/tradeQuote.ts
+++ b/test/fixtures/tradeQuote.ts
@@ -163,7 +163,7 @@ export const tradeQuoteFixtures = {
     from: '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b',
     fromTokenAddress: '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
     toTokenAddress: '0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e',
-    exchangeAdapterName: 'ZeroExApiAdapterV4',
+    exchangeAdapterName: 'ZeroExApiAdapterV5',
     calldata: '0x415565b00000000000000000000000009f8f72aa9304c8b593d555f12ef6589cc3a579a2',
     gas: '315000',
     gasPrice: '61',
@@ -201,7 +201,7 @@ export const tradeQuoteFixtures = {
     from: '0xd7dc13984d4fe87f389e50067fb3eedb3f704ea0',
     fromTokenAddress: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
     toTokenAddress: '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6',
-    exchangeAdapterName: 'ZeroExApiAdapterV4',
+    exchangeAdapterName: 'ZeroExApiAdapterV5',
     calldata:
      '0x415565b00000000000000000000000002791bca1f2de4661ed88a30c99a7a9449aa84174',
     gas: '315000',

--- a/test/fixtures/tradeQuote.ts
+++ b/test/fixtures/tradeQuote.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'ethers';
+import { ZERO_EX_ADAPTER_NAME } from '../../src/api/utils/tradeQuoter';
 
 export const tradeQuoteFixtures = {
   setDetailsResponseDPI: {
@@ -163,7 +164,7 @@ export const tradeQuoteFixtures = {
     from: '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b',
     fromTokenAddress: '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
     toTokenAddress: '0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e',
-    exchangeAdapterName: 'ZeroExApiAdapterV5',
+    exchangeAdapterName: ZERO_EX_ADAPTER_NAME,
     calldata: '0x415565b00000000000000000000000009f8f72aa9304c8b593d555f12ef6589cc3a579a2',
     gas: '315000',
     gasPrice: '61',
@@ -201,7 +202,7 @@ export const tradeQuoteFixtures = {
     from: '0xd7dc13984d4fe87f389e50067fb3eedb3f704ea0',
     fromTokenAddress: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
     toTokenAddress: '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6',
-    exchangeAdapterName: 'ZeroExApiAdapterV5',
+    exchangeAdapterName: ZERO_EX_ADAPTER_NAME,
     calldata:
      '0x415565b00000000000000000000000002791bca1f2de4661ed88a30c99a7a9449aa84174',
     gas: '315000',


### PR DESCRIPTION
Changes to accomodate https://github.com/SetProtocol/set-protocol-v2/pull/241 which restores RFQT support

(`set-ui` consumes this adapter name and passes it as a parameter to TradeModule calls)



**Requires**

- [x]  Enable new adapter in production on Ethereum, Polygon, Optimism