### PR TITLE
Remove excludedSources defaults from TradeQuoter [SIM-263]

### DIFF
--- a/src/api/utils/tradeQuoter.ts
+++ b/src/api/utils/tradeQuoter.ts
@@ -57,7 +57,7 @@ export class TradeQuoter {
   private feePercentage: number = 0;
   private isFirmQuote: boolean = true;
   private slippagePercentage: number = 2;
-  private excludedSources: string[] = ['Kyber', 'Eth2Dai', 'Mesh'];
+  private excludedSources: string[] = [];
   private zeroExApiKey: string;
   private zeroExApiUrls: ZeroExApiUrls;
 


### PR DESCRIPTION
We've had Kyber on this list (which causes problems issuing DPI since it contains KNC and KyberV3 has the best liquidity). 

Think the API consumer should set these explicitly and not be exposed to any historical preferences defined in the set-core implementation.